### PR TITLE
Exclude dependency 'javax.xml:xmldsig:1.0' which is (apparently) no l…

### DIFF
--- a/overlays/cas/build.gradle
+++ b/overlays/cas/build.gradle
@@ -7,7 +7,10 @@ dependencies {
     }
     runtime "net.sf.ehcache:ehcache-core:${ehcacheVersion}"
     runtime "org.jasig.cas:cas-server-webapp:${casServerVersion}@war"
-    runtime "org.jasig.cas:cas-server-extension-clearpass:${casServerVersion}"
+    runtime("org.jasig.cas:cas-server-extension-clearpass:${casServerVersion}") {
+        exclude group: 'commons-logging', module: 'commons-logging'
+        exclude group: 'javax.xml', module: 'xmldsig'
+    }
     runtime "xerces:xercesImpl:${xercesImplVersion}"
 
     compile "commons-codec:commons-codec:${commonsCodecVersion}"
@@ -18,16 +21,20 @@ dependencies {
 
     compileOnly("org.jasig.cas:cas-server-core:${casServerVersion}") {
         exclude group: 'commons-logging', module: 'commons-logging'
+        exclude group: 'javax.xml', module: 'xmldsig'
     }
     compileOnly("org.springframework:spring-jdbc:${springVersion}") {
         exclude group: 'commons-logging', module: 'commons-logging'
     }
     compileOnly servletApiDependency
 
-    testCompile group: 'org.easymock', name: 'easymock', version: '3.4'
     testCompile group: 'junit', name: 'junit', version: '4.12'
+    testCompile group: 'org.easymock', name: 'easymock', version: '3.4'
+    testCompile("org.jasig.cas:cas-server-core:${casServerVersion}") {
+        exclude group: 'commons-logging', module: 'commons-logging'
+        exclude group: 'javax.xml', module: 'xmldsig'
+    }
     testCompile group: 'org.springframework', name: 'spring-jdbc', version: springVersion
-    testCompile group: 'org.jasig.cas', name: 'cas-server-core', version: casServerVersion
 }
 
 war {


### PR DESCRIPTION
…onger available in Maven Central

This change excludes the `'javax.xml:xmldsig:1.0` dependency -- in all necessary ways -- from the `:overlays:cas` sub project.

The jar was once available in Maven Central (but it's not any longer).  I'm not sure if it's needed in the deployment or not, but it doesn't matter because the  `org.jasig.cas:cas-server-webapp:${casServerVersion}@war` dependency includes it anyway in `WEB-INF/lib`.

I am sure (relatively) that it's not needed for compiling (overlay) sources or for running tests.

<!--
Thank you for your pull request. Please review below requirements.

Bug fixes and new features should be reported on the issue tracker: https://issues.jasig.org/browse/UP/

Contributors guide: https://github.com/Jasig/uPortal/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

-   [x] the [individual contributor license agreement][] is signed
-   [x] commit message follows [commit guidelines][]

##### Description of change
<!-- Provide a description of the change below this comment. -->


<!-- Reference Links -->

[individual contributor license agreement]: https://github.com/Jasig/uPortal/blob/master/CONTRIBUTING.md#individual-contributor-license-agreement
[commit guidelines]: https://github.com/Jasig/uPortal/blob/master/CONTRIBUTING.md#commit
[message properties]: https://github.com/Jasig/uPortal/tree/master/uportal-war/src/main/resources/properties/i18n
[WCAG 2.0 AA]: https://www.w3.org/WAI/WCAG20/quickref/?levels=aaa&technologies=smil%2Cpdf%2Cflash%2Csl
