### PR TITLE
More explicitly document who are Committers for this repo

### DIFF
--- a/COMMITTERS.md
+++ b/COMMITTERS.md
@@ -1,0 +1,7 @@
+# Committers
+
+The Committers for this `uPortal-start` repo are the [uPortal Committers][].
+
+
+
+[uPortal Committers]: https://github.com/Jasig/uPortal/blob/master/docs/COMMITTERS.md


### PR DESCRIPTION
Documents in this repo who the Committers are, by referencing the Committers listing for the `Jasig/uPortal` repo.

##### Checklist

-   [x] the [individual contributor license agreement][] is signed
-   [x] documentation is changed or added


<!-- Reference Links -->

[individual contributor license agreement]: https://github.com/Jasig/uPortal/blob/master/CONTRIBUTING.md#individual-contributor-license-agreement
