### PR TITLE
UP-4876:  Refactor Gradle tasks 'portalDeploy' and 'portalClean' into…

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,11 +70,40 @@ running the following command:
 
 ### List of Examples:
 
+  - [How To Set Up Everything the First Time](#how-to-set-up-everything-the-first-time)
   - [How To Install Tomcat](#how-to-install-tomcat)
   - [How To Start the Embedded Database](#how-to-start-the-embedded-database)
   - [How To Deploy uPortal Technology to Tomcat](#how-to-deploy-uportal-technology-to-tomcat)
   - [How To Create and Initialize the Database Schema](#how-to-create-and-initialize-the-database-schema)
   - [How To Start Tomcat](#how-to-start-tomcat)
+
+### How To Set Up Everything the First Time
+
+The remaining examples (below) illustrate how to perform the most common uPortal tasks
+individually;  but there's an easy way to do all of them at once when you're just starting out.
+
+Use the following command to set up your portal the first time:
+
+```console
+    $ ./gradlew portalInit
+```
+
+This command performs the following steps:
+
+  - Starts the integrated HSQLDB instance (`hsqlStart`)
+  - Downloads, installs, and configures the integrated Tomcat servlet container (`tomcatInstall`)
+  - Deploys all uPortal web applications to Tomcat (`tomcatDeploy`)
+  - Creates the database schema, and imports both the Base & Implementation data sets (`dataInit`)
+
+:warning:  After this command, your HSQLDB instance will be running.  That's normally a good thing,
+but don't forget to stop it if you need to.
+
+:notebook:  Your Tomcat server, on the other hand, _will not be running_ when this command
+finishes.  Don't forget to [follow these instructions](#how-to-start-tomcat) to start it.
+
+:notebook:  You can run this command again later if you want to "reset" your environment to a clean
+state.  It's a good idea to **make sure both the Tomcat container and the HSQLDB instance are not
+running** when you do.
 
 ### How To Install Tomcat
 
@@ -126,11 +155,19 @@ working.
 You can do that with the following command:
 
 ```console
-    $ ./gradlew portalDeploy
+    $ ./gradlew tomcatDeploy
 ```
 
 :notebook:  you will need to _run this command again_ any time you make changes to anything inside
 the `overlays` folder.
+
+You can also run this command for one project at a time, for example...
+
+```console
+    $ ./gradlew :overlays:Announcements:tomcatDeploy
+```
+
+This is a great way to save time when you're working on a specific subproject.
 
 ### How To Create and Initialize the Database Schema
 

--- a/build.gradle
+++ b/build.gradle
@@ -3,7 +3,7 @@ import org.gradle.internal.os.OperatingSystem;
 ext {
     /*
      * We need to define the buildProperties extended property here in order for the
-     * build to compile.  It will be initialized by the :loadBuildProperties task.
+     * build to compile.  It will be bootstrapped during the Gradle initialization phase.
      */
     buildProperties = new Properties()
     /*
@@ -14,9 +14,14 @@ ext {
 }
 
 /*
+ * Load the buildProperties collection, which is used by the CLI Tools.
+ * (NOTE:  This item must come first.)
+ */
+apply from: rootProject.file('gradle/tasks/properties.gradle')
+
+/*
  * uPortal CLI Tools
  */
 apply from: rootProject.file('gradle/tasks/hsql.gradle')
 apply from: rootProject.file('gradle/tasks/portal.gradle')
-apply from: rootProject.file('gradle/tasks/properties.gradle')
 apply from: rootProject.file('gradle/tasks/tomcat.gradle')

--- a/build.gradle
+++ b/build.gradle
@@ -2,40 +2,15 @@ import org.gradle.internal.os.OperatingSystem;
 
 ext {
     /*
+     * We need to define the buildProperties extended property here in order for the
+     * build to compile.  It will be initialized by the :loadBuildProperties task.
+     */
+    buildProperties = new Properties()
+    /*
      * Unfortunately, several of the uPortal CLI tasks need to do
      * significantly different things on different operating systems.
      */
     isWindows = OperatingSystem.current().isWindows()
-    buildProps = new Properties();  // Initialized by the 'loadBuildProps' task, if needed
-}
-
-configurations {
-    bundled
-}
-
-/*
- * These are the "bundled" applications that deploy to Tomcat: portlets,
- * resource-server, and (starting with version 5.0) uPortal itself.
- */
-dependencies {
-    bundled project(path: ':overlays:Announcements', configuration: 'pluto')
-    bundled project(path: ':overlays:basiclti-portlet', configuration: 'pluto')
-    bundled project(path: ':overlays:BookmarksPortlet', configuration: 'pluto')
-    bundled project(path: ':overlays:CalendarPortlet', configuration: 'pluto')
-    bundled project(path: ':overlays:cas', configuration: 'war')
-    bundled project(path: ':overlays:cas-proxy-test-portlet', configuration: 'pluto')
-    bundled project(path: ':overlays:email-preview', configuration: 'pluto')
-    bundled project(path: ':overlays:FunctionalTestsPortlet', configuration: 'pluto')
-    bundled project(path: ':overlays:jasig-widget-portlets', configuration: 'pluto')
-    bundled project(path: ':overlays:NewsReaderPortlet', configuration: 'pluto')
-    bundled project(path: ':overlays:NotificationPortlet', configuration: 'pluto')
-    bundled project(path: ':overlays:pluto-testsuite', configuration: 'war')
-    bundled project(path: ':overlays:ResourceServingWebapp', configuration: 'war')
-    bundled project(path: ':overlays:sakai-connector', configuration: 'pluto')
-    bundled project(path: ':overlays:SimpleContentPortlet', configuration: 'pluto')
-    bundled project(path: ':overlays:uPortal', configuration: 'pluto')
-    bundled project(path: ':overlays:WeatherPortlet', configuration: 'pluto')
-    bundled project(path: ':overlays:WebProxyPortlet', configuration: 'pluto')
 }
 
 /*

--- a/buildSrc/src/main/groovy/org/apereo/portal/start/gradle/plugins/GradlePlutoPlugin.groovy
+++ b/buildSrc/src/main/groovy/org/apereo/portal/start/gradle/plugins/GradlePlutoPlugin.groovy
@@ -9,31 +9,33 @@ import org.gradle.api.Plugin
 class GradlePlutoPlugin implements Plugin<Project> {
     @Override
     void apply(Project project) {
+        File destinationDir = new File (project.buildDir, 'pluto')
+        File archiveOutput = new File(destinationDir, "${project.name}.war")
+
         project.task('plutoAssemble') {
             dependsOn project.tasks.war
             doLast {
                 File archiveSource = project.configurations.war.artifacts.files.iterator().next()
-                File destinationDir = new File (project.buildDir, 'pluto')
 
                 logger.lifecycle("Processing archive ${archiveSource.getName()} " +
                         "into destination directory ${destinationDir.getPath()} " +
                         "with the Apache Pluto Assembler")
 
                 destinationDir.mkdirs()
-                File archiveOutput = new File(destinationDir, archiveSource.getName())
 
                 AssemblerConfig config = new AssemblerConfig()
                 config.setSource(archiveSource)
                 config.setDestination(archiveOutput)
                 Assembler assembler = AssemblerFactory.getFactory().createAssembler(config)
                 assembler.assemble(config)
-
-                project.artifacts.add('pluto', archiveOutput)
-
             }
         }
         project.configurations {
             pluto {}
         }
+        project.artifacts {
+            pluto archiveOutput
+        }
+        project.tasks.assemble.dependsOn 'plutoAssemble'
     }
 }

--- a/buildSrc/src/main/groovy/org/apereo/portal/start/gradle/plugins/GradleTomcatDeployPlugin.groovy
+++ b/buildSrc/src/main/groovy/org/apereo/portal/start/gradle/plugins/GradleTomcatDeployPlugin.groovy
@@ -1,0 +1,46 @@
+package org.apereo.portal.start.gradle.plugins
+
+import org.gradle.api.Plugin
+import org.gradle.api.Project
+import org.gradle.api.tasks.Delete
+
+class GradleTomcatDeployPlugin implements Plugin<Project> {
+    @Override
+    void apply(Project project) {
+        project.task('tomcatClean', type: Delete) {
+            group 'Tomcat'
+            description 'Removes this project from the integrated Tomcat servlet container'
+            dependsOn ':loadBuildProperties'
+
+            doFirst {
+                File serverHome = new File(project.rootProject.projectDir, project.rootProject.ext['buildProperties'].getProperty('server.home'))
+                File deployDir = new File (serverHome, "webapps/${project.name}")
+                logger.lifecycle("Removing deployed application from servlet container at location:  ${deployDir}")
+                delete deployDir
+            }
+        }
+        project.task('tomcatDeploy') {
+            group 'Tomcat'
+            description 'Deploys this project to the integrated Tomcat servlet container'
+            dependsOn 'tomcatClean'
+            dependsOn 'assemble'
+
+            doFirst {
+                File serverHome = new File(project.rootProject.projectDir, project.rootProject.ext['buildProperties'].getProperty('server.home'))
+                File deployDir = new File (serverHome, "webapps/${project.name}")
+                logger.lifecycle("Deploying assembled application to servlet container at location:  ${deployDir}")
+
+                String artifactDir = project.plugins.hasPlugin(GradlePlutoPlugin) ? 'pluto' : 'libs'
+                File warFile = new File("${project.buildDir}/${artifactDir}/${project.name}.war")
+
+                project.copy {
+                    with project.copySpec {
+                        from project.zipTree(warFile)
+                    }
+                    into deployDir
+                }
+
+            }
+        }
+    }
+}

--- a/buildSrc/src/main/groovy/org/apereo/portal/start/gradle/plugins/GradleTomcatDeployPlugin.groovy
+++ b/buildSrc/src/main/groovy/org/apereo/portal/start/gradle/plugins/GradleTomcatDeployPlugin.groovy
@@ -10,7 +10,6 @@ class GradleTomcatDeployPlugin implements Plugin<Project> {
         project.task('tomcatClean', type: Delete) {
             group 'Tomcat'
             description 'Removes this project from the integrated Tomcat servlet container'
-            dependsOn ':loadBuildProperties'
 
             doFirst {
                 File serverHome = new File(project.rootProject.projectDir, project.rootProject.ext['buildProperties'].getProperty('server.home'))

--- a/buildSrc/src/main/resources/buildDefaults.properties
+++ b/buildSrc/src/main/resources/buildDefaults.properties
@@ -1,27 +1,27 @@
 #
-# Licensed to Jasig under one or more contributor license
+# Licensed to Apereo under one or more contributor license
 # agreements. See the NOTICE file distributed with this work
 # for additional information regarding copyright ownership.
-# Jasig licenses this file to you under the Apache License,
+# Apereo licenses this file to you under the Apache License,
 # Version 2.0 (the "License"); you may not use this file
-# except in compliance with the License. You may obtain a
-# copy of the License at:
+# except in compliance with the License.  You may obtain a
+# copy of the License at the following location:
 #
-# http://www.apache.org/licenses/LICENSE-2.0
+#   http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing,
-# software distributed under the License is distributed on
-# an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
-# KIND, either express or implied. See the License for the
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
 #
 
 #
-# Modify this file to suit your local environment.
-# The values of these properties will
-# override the values of properties of the
-# same name in the buildDefaults.properties file.
+# Adopting institutions should modify this file to include adopter-specific
+# defaults.  These settings will apply to the build only if they are not
+# overridden by higher-priority means.  You can override these settings by
+# providing a build.properties file or with JVM arguments.
 #
 # Use forward slashes for path names even if
 # you are in a Windows environment!
@@ -29,16 +29,16 @@
 
 # Location of the integrated Tomcat installation; e.g. server.home=${env.CATALINA_HOME}
 #
-#server.home=
+server.home=.gradle/tomcat
 
 # Location of Base Data Set;  base data is imported before entities specified
 # in implementation.entities.location (below) and does not commonly require
 # adopter customization.
 #
-#base.entities.location=
+base.entities.location=data/base
 
 # Location of the Implementation Data Set;  entities in this folder should be
 # heavily customized by adopters.  IMPORTANT!:  We recommend making a copy of
 # the quickstart folder and changing this setting.
 #
-#implementation.entities.location=
+implementation.entities.location=data/quickstart

--- a/gradle/tasks/portal.gradle
+++ b/gradle/tasks/portal.gradle
@@ -1,6 +1,6 @@
 task portalInit {
     group 'Portal'
-    description 'All-in-one task that starts the intgrated HSQLDB instance, downloads & installs ' +
+    description 'All-in-one task that starts the integrated HSQLDB instance, downloads & installs ' +
             'the integrated Tomcat servlet container, deploys all uPortal technology to Tomcat, ' +
             'creates the database schema, and imports both the Base & Implementation data sets'
     dependsOn allprojects.collect { it.tasks.matching { it.name.equals('clean') } }

--- a/gradle/tasks/portal.gradle
+++ b/gradle/tasks/portal.gradle
@@ -1,35 +1,11 @@
-task portalClean(type: Delete, dependsOn: 'loadBuildProps') {
+task portalInit {
     group 'Portal'
-    description 'Removes the deployed uPortal from the servlet container.'
-    followSymlinks = true
-
-    doFirst {
-        String serverHome = buildProps.getProperty('server.home') ?: defaultServerHome
-        def uPortalDeployDir = "${serverHome}/webapps/uPortal"
-        logger.lifecycle("Removing deployed uPortal from servlet container at location:  ${uPortalDeployDir}")
-        delete uPortalDeployDir
-    }
-}
-
-task portalDeploy(dependsOn: 'loadBuildProps') {
-    group 'Portal'
-    description 'Deploys uPortal and all bundled war files to the embedded Tomcat servlet container'
-    dependsOn 'portalClean'
-    dependsOn getTasksByName('war', true)
-    dependsOn getTasksByName('plutoAssemble', true)
-
-    doLast {
-        String serverHome = buildProps.getProperty('server.home') ?: defaultServerHome
-        logger.lifecycle("Deploying bundled applications to the Tomcat servlet container in ${serverHome}...")
-
-        configurations.bundled.files.each { war ->
-            logger.lifecycle("  --> ${war}")
-            copy {
-                into "${serverHome}/webapps/${war.getName().take(war.getName().lastIndexOf('.'))}"
-                with copySpec {
-                    from zipTree(war)
-                }
-            }
-        }
-    }
+    description 'All-in-one task that starts the intgrated HSQLDB instance, downloads & installs ' +
+            'the integrated Tomcat servlet container, deploys all uPortal technology to Tomcat, ' +
+            'creates the database schema, and imports both the Base & Implementation data sets'
+    dependsOn allprojects.collect { it.tasks.matching { it.name.equals('clean') } }
+    dependsOn ':hsqlStart'
+    dependsOn ':tomcatInstall'
+    dependsOn allprojects.collect { it.tasks.matching { it.name.equals('tomcatDeploy') } }
+    dependsOn allprojects.collect { it.tasks.matching { it.name.equals('dataInit') } }
 }

--- a/gradle/tasks/properties.gradle
+++ b/gradle/tasks/properties.gradle
@@ -1,14 +1,60 @@
-task loadBuildProps() {
+task loadBuildProperties() {
     group 'Properties'
-    description 'Loads build settings from the build.properties file'
+    description 'Loads build settings from the defults.properties, build.properties, and JMV arguments (in that order)'
 
     doLast {
-        logger.lifecycle('Reading build.properties')
+
+        /*
+         * The Properties object we need to load already exists.
+         */
+        Properties buildProperties = rootProject.ext['buildProperties']
+
+        /*
+         * Start with buildDefaults.properties from the classpath.
+         */
+        InputStream defaults = this.getClass().getClassLoader().getResourceAsStream('buildDefaults.properties')
+        if (defaults == null) {
+            // The defaults.properties is missing;  this situation is untenable
+            throw new GradleScriptException('buildDefaults.properties file not found')
+        }
+        buildProperties.load(defaults)
+
+        /*
+         * The next layer is build.properties in the root directory of the
+         * project;  but it's not required.
+         */
         def buildPropsFile = file('build.properties')
         if (buildPropsFile.exists()) {
-            buildPropsFile.withInputStream { buildProps.load(it) }
+            // Anything in here trumps what we loaded earlier...
+            Properties localBuildProps = new Properties()
+            buildPropsFile.withInputStream { localBuildProps.load(it) }
+            localBuildProps.forEach { key, value ->
+                buildProperties.setProperty(key, value)
+            }
         } else {
             logger.lifecycle('No build.properties file found;  continuing with default build settings')
         }
+
+        /*
+         * The final layer is JVM arguments;  anything you specify on the
+         * command line will be honored over both the default & local
+         * settings.
+         */
+        buildProperties.forEach { key, value ->
+            String jvmArgValue = System.getProperty(key);
+            if (jvmArgValue) {
+                logger.lifecycle("Found JVM override value of '${jvmArgValue}' for build property '${key}'")
+                buildProperties.setProperty(key, jvmArgValue)
+            }
+        }
+
+        /*
+         * List the complete set of build properties to the console.
+         */
+        logger.lifecycle('Using the following build properties:')
+        buildProperties.forEach { key, value ->
+            logger.lifecycle("  -> ${key}=${value}")
+        }
+
     }
 }

--- a/gradle/tasks/properties.gradle
+++ b/gradle/tasks/properties.gradle
@@ -1,60 +1,57 @@
-task loadBuildProperties() {
-    group 'Properties'
-    description 'Loads build settings from the defults.properties, build.properties, and JMV arguments (in that order)'
+/*
+ * Loads the buildProperties collection during the Gradle initialization phase.
+ */
+def loadBuildProperties = {
+    /*
+     * The Properties object we need to load already exists.
+     */
+    Properties buildProperties = rootProject.ext['buildProperties']
 
-    doLast {
-
-        /*
-         * The Properties object we need to load already exists.
-         */
-        Properties buildProperties = rootProject.ext['buildProperties']
-
-        /*
-         * Start with buildDefaults.properties from the classpath.
-         */
-        InputStream defaults = this.getClass().getClassLoader().getResourceAsStream('buildDefaults.properties')
-        if (defaults == null) {
-            // The defaults.properties is missing;  this situation is untenable
-            throw new GradleScriptException('buildDefaults.properties file not found')
-        }
-        buildProperties.load(defaults)
-
-        /*
-         * The next layer is build.properties in the root directory of the
-         * project;  but it's not required.
-         */
-        def buildPropsFile = file('build.properties')
-        if (buildPropsFile.exists()) {
-            // Anything in here trumps what we loaded earlier...
-            Properties localBuildProps = new Properties()
-            buildPropsFile.withInputStream { localBuildProps.load(it) }
-            localBuildProps.forEach { key, value ->
-                buildProperties.setProperty(key, value)
-            }
-        } else {
-            logger.lifecycle('No build.properties file found;  continuing with default build settings')
-        }
-
-        /*
-         * The final layer is JVM arguments;  anything you specify on the
-         * command line will be honored over both the default & local
-         * settings.
-         */
-        buildProperties.forEach { key, value ->
-            String jvmArgValue = System.getProperty(key);
-            if (jvmArgValue) {
-                logger.lifecycle("Found JVM override value of '${jvmArgValue}' for build property '${key}'")
-                buildProperties.setProperty(key, jvmArgValue)
-            }
-        }
-
-        /*
-         * List the complete set of build properties to the console.
-         */
-        logger.lifecycle('Using the following build properties:')
-        buildProperties.forEach { key, value ->
-            logger.lifecycle("  -> ${key}=${value}")
-        }
-
+    /*
+     * Start with buildDefaults.properties from the classpath.
+     */
+    InputStream defaults = this.getClass().getClassLoader().getResourceAsStream('buildDefaults.properties')
+    if (defaults == null) {
+        // The defaults.properties is missing;  this situation is untenable
+        throw new GradleScriptException('buildDefaults.properties file not found')
     }
-}
+    buildProperties.load(defaults)
+
+    /*
+     * The next layer is build.properties in the root directory of the
+     * project;  but it's not required.
+     */
+    def buildPropsFile = file('build.properties')
+    if (buildPropsFile.exists()) {
+        // Anything in here trumps what we loaded earlier...
+        Properties localBuildProps = new Properties()
+        buildPropsFile.withInputStream { localBuildProps.load(it) }
+        localBuildProps.forEach { key, value ->
+            buildProperties.setProperty(key, value)
+        }
+    } else {
+        logger.lifecycle('No build.properties file found;  continuing with default build settings')
+    }
+
+    /*
+     * The final layer is JVM arguments;  anything you specify on the
+     * command line will be honored over both the default & local
+     * settings.
+     */
+    buildProperties.forEach { key, value ->
+        String jvmArgValue = System.getProperty(key);
+        if (jvmArgValue) {
+            logger.lifecycle("Found JVM override value of '${jvmArgValue}' for build property '${key}'")
+            buildProperties.setProperty(key, jvmArgValue)
+        }
+    }
+
+    /*
+     * List the complete set of build properties to the console.
+     */
+    logger.lifecycle('Using the following build properties:')
+    buildProperties.forEach { key, value ->
+        logger.lifecycle("  -> ${key}=${value}")
+    }
+
+}()

--- a/gradle/tasks/tomcat.gradle
+++ b/gradle/tasks/tomcat.gradle
@@ -19,7 +19,7 @@ dependencies {
     shared "${portletApiDependency}"
 }
 
-task tomcatInstall(dependsOn: 'loadBuildProperties') {
+task tomcatInstall() {
     description 'Downloads the Apache Tomcat servlet container and performs the necessary configuration steps'
 
     doLast {
@@ -82,7 +82,7 @@ task tomcatInstall(dependsOn: 'loadBuildProperties') {
     }
 }
 
-task tomcatStart(dependsOn: 'loadBuildProperties') {
+task tomcatStart() {
     group 'Tomcat'
     description 'Start the embedded Tomcat servlet container'
 
@@ -99,7 +99,7 @@ task tomcatStart(dependsOn: 'loadBuildProperties') {
     }
 }
 
-task tomcatStop(dependsOn: 'loadBuildProperties') {
+task tomcatStop() {
     group 'Tomcat'
     description 'Stop the embedded Tomcat servlet container'
 
@@ -116,7 +116,7 @@ task tomcatStop(dependsOn: 'loadBuildProperties') {
     }
 }
 
-task tomcatClearLogs(type: Delete, dependsOn: 'loadBuildProperties') {
+task tomcatClearLogs(type: Delete) {
     group 'Tomcat'
     description 'Delete all log files within Tomcat'
 

--- a/gradle/tasks/tomcat.gradle
+++ b/gradle/tasks/tomcat.gradle
@@ -118,17 +118,17 @@ task tomcatStop(dependsOn: 'loadBuildProperties') {
 
 task tomcatClearLogs(type: Delete, dependsOn: 'loadBuildProperties') {
     description 'Delete log files within Tomcat'
-    String serverHome = rootProject.ext['buildProperties'].getProperty('server.home')
 
     doFirst {
-        fileTree("${serverHome}/logs").visit { FileVisitDetails file ->
-            logger.lifecycle("Deleting ${file.name}")
+        String serverHome = rootProject.ext['buildProperties'].getProperty('server.home')
+        boolean logsDirEmpty = true
+        fileTree("${serverHome}/logs").visit { FileVisitDetails details ->
+            logger.lifecycle("Deleting ${details.name}")
+            logsDirEmpty = false
+            delete details.file
         }
-    }
-
-    delete "${serverHome}/logs"
-
-    doLast {
-        file("${serverHome}/logs").mkdirs()
+        if (logsDirEmpty) {
+            logger.lifecycle('The Tomcat logs directory is empty;  there is noting to delete')
+        }
     }
 }

--- a/gradle/tasks/tomcat.gradle
+++ b/gradle/tasks/tomcat.gradle
@@ -1,7 +1,3 @@
-ext {
-    defaultServerHome = "${projectDir.getPath()}/.gradle/tomcat"
-}
-
 repositories {
     mavenLocal()
     mavenCentral()
@@ -23,11 +19,11 @@ dependencies {
     shared "${portletApiDependency}"
 }
 
-task tomcatInstall(dependsOn: 'loadBuildProps') {
+task tomcatInstall(dependsOn: 'loadBuildProperties') {
     description 'Downloads the Apache Tomcat servlet container and performs the necessary configuration steps'
 
     doLast {
-        String serverHome = buildProps.getProperty('server.home') ?: defaultServerHome
+        String serverHome = rootProject.ext['buildProperties'].getProperty('server.home')
 
         logger.lifecycle("Installing Tomcat servlet container version ${tomcatVersion} to location ${serverHome}")
 
@@ -86,12 +82,12 @@ task tomcatInstall(dependsOn: 'loadBuildProps') {
     }
 }
 
-task tomcatStart(dependsOn: 'loadBuildProps') {
+task tomcatStart(dependsOn: 'loadBuildProperties') {
     group 'Tomcat'
     description 'Start the embedded Tomcat servlet container'
 
     doLast {
-        String serverHome = buildProps.getProperty('server.home') ?: defaultServerHome
+        String serverHome = rootProject.ext['buildProperties'].getProperty('server.home')
         logger.lifecycle("Starting Tomcat servlet container in ${serverHome}")
         String executable = isWindows ? 'cmd' : './startup.sh'
         ant.exec(dir: "${serverHome}/bin", executable: executable, spawn: true) {
@@ -103,12 +99,12 @@ task tomcatStart(dependsOn: 'loadBuildProps') {
     }
 }
 
-task tomcatStop(dependsOn: 'loadBuildProps') {
+task tomcatStop(dependsOn: 'loadBuildProperties') {
     group 'Tomcat'
     description 'Stop the embedded Tomcat servlet container'
 
     doLast {
-        String serverHome = buildProps.getProperty('server.home') ?: defaultServerHome
+        String serverHome = rootProject.ext['buildProperties'].getProperty('server.home')
         logger.lifecycle("Stopping Tomcat servlet container in ${serverHome}")
         String executable = isWindows ? 'cmd' : './shutdown.sh'
         ant.exec(dir: "${serverHome}/bin", executable: executable, spawn: true) {
@@ -120,9 +116,9 @@ task tomcatStop(dependsOn: 'loadBuildProps') {
     }
 }
 
-task tomcatClearLogs(type: Delete, dependsOn: 'loadBuildProps') {
+task tomcatClearLogs(type: Delete, dependsOn: 'loadBuildProperties') {
     description 'Delete log files within Tomcat'
-    String serverHome = buildProps.getProperty('server.home') ?: defaultServerHome
+    String serverHome = rootProject.ext['buildProperties'].getProperty('server.home')
 
     doFirst {
         fileTree("${serverHome}/logs").visit { FileVisitDetails file ->

--- a/gradle/tasks/tomcat.gradle
+++ b/gradle/tasks/tomcat.gradle
@@ -117,18 +117,19 @@ task tomcatStop(dependsOn: 'loadBuildProperties') {
 }
 
 task tomcatClearLogs(type: Delete, dependsOn: 'loadBuildProperties') {
-    description 'Delete log files within Tomcat'
+    group 'Tomcat'
+    description 'Delete all log files within Tomcat'
 
     doFirst {
         String serverHome = rootProject.ext['buildProperties'].getProperty('server.home')
-        boolean logsDirEmpty = true
-        fileTree("${serverHome}/logs").visit { FileVisitDetails details ->
-            logger.lifecycle("Deleting ${details.name}")
-            logsDirEmpty = false
-            delete details.file
-        }
-        if (logsDirEmpty) {
+        FileTree logsFolder = fileTree("${serverHome}/logs")
+        if (logsFolder.isEmpty()) {
             logger.lifecycle('The Tomcat logs directory is empty;  there is noting to delete')
+        } else {
+            logsFolder.visit { FileVisitDetails details ->
+                logger.lifecycle("Deleting ${details.name}")
+                delete details.file
+            }
         }
     }
 }

--- a/overlays/Announcements/build.gradle
+++ b/overlays/Announcements/build.gradle
@@ -27,7 +27,6 @@ dependencies {
 }
 
 dataInit {
-    dependsOn ':loadBuildProperties'
     /*
      * Drop (if present) then create the Hibernate-managed schema.
      */

--- a/overlays/Announcements/build.gradle
+++ b/overlays/Announcements/build.gradle
@@ -27,7 +27,7 @@ dependencies {
 }
 
 dataInit {
-    dependsOn ':loadBuildProps'
+    dependsOn ':loadBuildProperties'
     /*
      * Drop (if present) then create the Hibernate-managed schema.
      */
@@ -49,7 +49,7 @@ dataInit {
      * specified by 'implementation.entities.location'.
      */
     doLast {
-        String implementationEntitiesLocation = PortalShellInvoker.createGroovySafePath(buildProps.getProperty('implementation.entities.location') ?: defaultImplementationEntitiesLocation)
+        String implementationEntitiesLocation = PortalShellInvoker.createGroovySafePath(rootProject.ext['buildProperties'].getProperty('implementation.entities.location'))
 
         ant.setLifecycleLogLevel('INFO')
         ant.java(fork: true, failonerror: true, dir: rootProject.projectDir, classname: 'org.jasig.portlet.announcements.Importer') {

--- a/overlays/CalendarPortlet/build.gradle
+++ b/overlays/CalendarPortlet/build.gradle
@@ -27,7 +27,7 @@ dependencies {
 }
 
 dataInit {
-    dependsOn ':loadBuildProps'
+    dependsOn ':loadBuildProperties'
     /*
      * Drop (if present) then create the Hibernate-managed schema.
      */
@@ -62,7 +62,7 @@ dataInit {
      * specified by 'implementation.entities.location'.
      */
     doLast {
-        String implementationEntitiesLocation = PortalShellInvoker.createGroovySafePath(buildProps.getProperty('implementation.entities.location') ?: defaultImplementationEntitiesLocation)
+        String implementationEntitiesLocation = PortalShellInvoker.createGroovySafePath(rootProject.ext['buildProperties'].getProperty('implementation.entities.location'))
 
         ant.setLifecycleLogLevel('INFO')
         ant.java(fork: true, failonerror: true, dir: rootProject.projectDir, classname: 'org.danann.cernunnos.runtime.Main') {

--- a/overlays/CalendarPortlet/build.gradle
+++ b/overlays/CalendarPortlet/build.gradle
@@ -27,7 +27,6 @@ dependencies {
 }
 
 dataInit {
-    dependsOn ':loadBuildProperties'
     /*
      * Drop (if present) then create the Hibernate-managed schema.
      */

--- a/overlays/NewsReaderPortlet/build.gradle
+++ b/overlays/NewsReaderPortlet/build.gradle
@@ -27,7 +27,7 @@ dependencies {
 }
 
 dataInit {
-    dependsOn ':loadBuildProps'
+    dependsOn ':loadBuildProperties'
     /*
      * Drop (if present) then create the Hibernate-managed schema.
      */
@@ -62,7 +62,7 @@ dataInit {
      * specified by 'implementation.entities.location'.
      */
     doLast {
-        String implementationEntitiesLocation = PortalShellInvoker.createGroovySafePath(buildProps.getProperty('implementation.entities.location') ?: defaultImplementationEntitiesLocation)
+        String implementationEntitiesLocation = PortalShellInvoker.createGroovySafePath(rootProject.ext['buildProperties'].getProperty('implementation.entities.location'))
 
         ant.setLifecycleLogLevel('INFO')
         ant.java(fork: true, failonerror: true, dir: rootProject.projectDir, classname: 'org.danann.cernunnos.runtime.Main') {

--- a/overlays/NewsReaderPortlet/build.gradle
+++ b/overlays/NewsReaderPortlet/build.gradle
@@ -27,7 +27,6 @@ dependencies {
 }
 
 dataInit {
-    dependsOn ':loadBuildProperties'
     /*
      * Drop (if present) then create the Hibernate-managed schema.
      */

--- a/overlays/SimpleContentPortlet/build.gradle
+++ b/overlays/SimpleContentPortlet/build.gradle
@@ -27,7 +27,7 @@ dependencies {
 }
 
 dataInit {
-    dependsOn ':loadBuildProps'
+    dependsOn ':loadBuildProperties'
     /*
      * Drop (if present) then create the Hibernate-managed schema.
      */

--- a/overlays/SimpleContentPortlet/build.gradle
+++ b/overlays/SimpleContentPortlet/build.gradle
@@ -27,7 +27,6 @@ dependencies {
 }
 
 dataInit {
-    dependsOn ':loadBuildProperties'
     /*
      * Drop (if present) then create the Hibernate-managed schema.
      */

--- a/overlays/build.gradle
+++ b/overlays/build.gradle
@@ -8,13 +8,9 @@ buildscript {
 }
 
 subprojects {
-    ext {
-        defaultBaseEntitiesLocation = "${rootProject.projectDir}/data/base"
-        defaultImplementationEntitiesLocation = "${rootProject.projectDir}/data/quickstart"
-    }
-
     apply plugin: 'maven'
     apply plugin: 'waroverlay'
+    apply plugin: org.apereo.portal.start.gradle.plugins.GradleTomcatDeployPlugin
 
     repositories {
         mavenLocal()
@@ -80,5 +76,14 @@ subprojects {
         from zipTree("${project.buildDir}/libs/${project.name}.war")
         into "${buildDir}/${project.name}"
     }
+
+    /*
+     * Follow the pattern where 'assemble' is the generic task for building artifacts.  This allows
+     * us to develop plugins with simply 'dependsOn assemble' instead of worrying about what sorts
+     * of artifacts they produce. All subproject will have (at least) 'expandedWar';  some
+     * subprojects will also have 'plutoAssemble' (which is made a dependency of 'assemble' by the
+     * plugin).
+     */
+    assemble.dependsOn 'expandedWar'
 
 }

--- a/overlays/uPortal/build.gradle
+++ b/overlays/uPortal/build.gradle
@@ -23,7 +23,7 @@ ext {
 }
 
 dataInit {
-    dependsOn ':loadBuildProps'
+    dependsOn ':loadBuildProperties'
     /*
      * Add to the scriptFile commands that drop then create then load the legacy database
      * tables and data (i.e. non-Hibernate stuff that's still based on tables.xml and data.xml)
@@ -76,8 +76,8 @@ portalShellBuildHelper.hibernateCreate('db-hibernate',
      * the folder defined by the 'base.entities.location' build property.
      */
     doLast {
-        String baseEntitiesLocation = PortalShellInvoker.createGroovySafePath(buildProps.getProperty('base.entities.location') ?: defaultBaseEntitiesLocation)
-        String implementationEntitiesLocation = PortalShellInvoker.createGroovySafePath(buildProps.getProperty('implementation.entities.location') ?: defaultImplementationEntitiesLocation)
+        String baseEntitiesLocation = PortalShellInvoker.createGroovySafePath(rootProject.ext['buildProperties'].getProperty('base.entities.location'))
+        String implementationEntitiesLocation = PortalShellInvoker.createGroovySafePath(rootProject.ext['buildProperties'].getProperty('implementation.entities.location'))
 
         String pattern = ' '
         String file = ' '
@@ -111,7 +111,7 @@ portalShellBuildHelper.dataImport('data-import',
 }
 
 dataImport {
-    dependsOn ':loadBuildProps'
+    dependsOn ':loadBuildProperties'
     doLast {
         // Validate inputs
         Map<String,String> args = [
@@ -159,7 +159,7 @@ portalShellBuildHelper.dataImport("data-import",
 }
 
 dataExport {
-    dependsOn ':loadBuildProps'
+    dependsOn ':loadBuildProperties'
     doLast {
         // Three -D arguments may be passed;  all are optional
         String dir = System.getProperty('dir') ?: "${buildDir}/export"
@@ -189,7 +189,7 @@ portalShellBuildHelper.dataExport('data-export',
 }
 
 dataDelete {
-    dependsOn ':loadBuildProps'
+    dependsOn ':loadBuildProperties'
     doLast {
         // Validate inputs
         Map<String,String> args = [
@@ -225,7 +225,7 @@ portalShellBuildHelper.dataDelete('data-delete',
 }
 
 dataList {
-    dependsOn ':loadBuildProps'
+    dependsOn ':loadBuildProperties'
     doLast {
         // Is there a -Dtype= argument passed?
         String type = System.getProperty('type') ?: ' '

--- a/overlays/uPortal/build.gradle
+++ b/overlays/uPortal/build.gradle
@@ -23,7 +23,6 @@ ext {
 }
 
 dataInit {
-    dependsOn ':loadBuildProperties'
     /*
      * Add to the scriptFile commands that drop then create then load the legacy database
      * tables and data (i.e. non-Hibernate stuff that's still based on tables.xml and data.xml)
@@ -111,7 +110,6 @@ portalShellBuildHelper.dataImport('data-import',
 }
 
 dataImport {
-    dependsOn ':loadBuildProperties'
     doLast {
         // Validate inputs
         Map<String,String> args = [
@@ -159,7 +157,6 @@ portalShellBuildHelper.dataImport("data-import",
 }
 
 dataExport {
-    dependsOn ':loadBuildProperties'
     doLast {
         // Three -D arguments may be passed;  all are optional
         String dir = System.getProperty('dir') ?: "${buildDir}/export"
@@ -189,7 +186,6 @@ portalShellBuildHelper.dataExport('data-export',
 }
 
 dataDelete {
-    dependsOn ':loadBuildProperties'
     doLast {
         // Validate inputs
         Map<String,String> args = [
@@ -225,7 +221,6 @@ portalShellBuildHelper.dataDelete('data-delete',
 }
 
 dataList {
-    dependsOn ':loadBuildProperties'
     doLast {
         // Is there a -Dtype= argument passed?
         String type = System.getProperty('type') ?: ' '

--- a/overlays/uPortal/src/main/resources/command-line.logback.xml
+++ b/overlays/uPortal/src/main/resources/command-line.logback.xml
@@ -1,0 +1,109 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Licensed to Apereo under one or more contributor license
+    agreements. See the NOTICE file distributed with this work
+    for additional information regarding copyright ownership.
+    Apereo licenses this file to you under the Apache License,
+    Version 2.0 (the "License"); you may not use this file
+    except in compliance with the License.  You may obtain a
+    copy of the License at the following location:
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied.  See the License for the
+    specific language governing permissions and limitations
+    under the License.
+
+-->
+<configuration>
+  <contextName>uPortal-command-line</contextName>
+
+  <contextListener class="ch.qos.logback.classic.jul.LevelChangePropagator">
+    <resetJUL>true</resetJUL>
+  </contextListener>
+
+  <appender name="CONSOLE" class="ch.qos.logback.core.ConsoleAppender">
+    <encoder>
+      <pattern>%-5level [%date{mm:ss.SSS}] %m%n</pattern>
+    </encoder>
+  </appender>
+
+  <!--
+   | Insert the current time formatted as "yyyyMMdd'T'HHmmss" under
+   | the key "bySecond" into the logger context. This value will be
+   | available to all subsequent configuration elements.
+   +-->
+  <timestamp key="bySecond" datePattern="yyyyMMdd'T'HHmmss"/>
+
+  <!--
+  <appender name="F" class="ch.qos.logback.core.FileAppender">
+    <File>cmdline-${bySecond}.log</File>
+    <encoder>
+      <pattern>%-5level [%thread] %logger{36} %d{ISO8601} - %msg%n</pattern>
+    </encoder>
+  </appender>
+   -->
+
+  <root level="WARN">
+    <appender-ref ref="CONSOLE"/>
+  </root>
+  <logger name="org.hibernate.dialect" additivity="false" level="INFO">
+    <appender-ref ref="CONSOLE"/>
+  </logger>
+  <logger name="org.apereo.portal" additivity="false" level="INFO">
+    <appender-ref ref="CONSOLE"/>
+  </logger>
+
+  <!-- Debugging event aggregation
+  <logger name="org.apereo.portal.concurrency.locking" additivity="false" level="DEBUG">
+    <appender-ref ref="CONSOLE"/>
+  </logger>
+  <logger name="org.apereo.portal.events" additivity="false" level="DEBUG">
+    <appender-ref ref="CONSOLE"/>
+  </logger>
+   -->
+
+  <!-- Debugging database issues during import/export/delete
+  <logger name="org.apereo.portal.io.xml.JaxbPortalDataHandlerService" additivity="false" level="TRACE">
+    <appender-ref ref="CONSOLE"/>
+  </logger>
+  <logger name="org.springframework.orm.jpa.JpaTransactionManager" additivity="false" level="DEBUG">
+    <appender-ref ref="CONSOLE"/>
+  </logger>
+  <logger name="org.hibernate.SQL" additivity="false" level="DEBUG">
+    <appender-ref ref="CONSOLE"/>
+  </logger>
+  <logger name="org.hibernate.type" additivity="false" level="DEBUG">
+    <appender-ref ref="CONSOLE"/>
+  </logger>
+   -->
+
+  <!--
+  <logger name="org.springframework.jdbc.core" additivity="false" level="TRACE">
+    <appender-ref ref="CONSOLE"/>
+  </logger>
+   -->
+
+  <!-- Hide Validation Query Resolution Warnings, not all DBs may be working during import/export -->
+  <logger name="org.apereo.portal.utils.jdbc.DelayedValidationQueryResolverImpl" additivity="false" level="ERROR"/>
+  <logger name="org.apereo.portal.utils.jdbc.TomcatDataSourceFactory" additivity="false" level="ERROR"/>
+
+  <!-- Hide some bad Hibernate log messages -->
+  <logger name="org.hibernate.cfg.annotations.reflection.JPAOverriddenAnnotationReader" additivity="false" level="ERROR"/>
+  <logger name="org.hibernate.ejb.metamodel.MetadataContext" additivity="false" level="FATAL"/>
+  <logger name="org.hibernate.engine.jdbc.spi.SqlExceptionHelper" additivity="false" level="FATAL"/>
+
+  <!-- Hide some bad JGroups log messages -->
+  <logger name="org.jgroups.protocols" additivity="false" level="WARN"/>
+
+  <!-- Hide some warning messages associated with PAGS and Person Directory for group import -->
+  <logger name="org.jasig.services.persondir.support.MergingPersonAttributeDaoImpl" additivity="false" level="ERROR"/>
+  <logger name="org.apereo.portal.persondir.support.PersonManagerCurrentUserProvider" additivity="false" level="ERROR"/>
+  <logger name="org.jasig.services.persondir.support.AdditionalDescriptorsPersonAttributeDao" additivity="false" level="ERROR"/>
+  <logger name="org.apereo.portal.groups.pags.testers.ThemeNameEqualsIgnoreCaseTester" additivity="false" level="ERROR"/>
+  <logger name="org.hibernate.engine.jdbc.internal.JdbcResourceRegistryImpl" additivity="false" level="ERROR"/>
+</configuration>


### PR DESCRIPTION
… a new GradleTomcatDeployPlugin plugin;  also improves buildProperties;  also adds a 'portalInit' task that bundles hsqlStart, tomcatInstall, tomcatDeploy, and dataInit into an all-in-one task

https://issues.jasig.org/browse/UP-4876

<!--
Thank you for your pull request. Please review below requirements.

Bug fixes and new features should be reported on the issue tracker: https://issues.jasig.org/browse/UP/

Contributors guide: https://github.com/Jasig/uPortal/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

-   [x] the [individual contributor license agreement][] is signed
-   [x] commit message follows [commit guidelines][]
-   [x] documentation is changed or added

##### Description of change
<!-- Provide a description of the change below this comment. -->

There's a working version of 'portalDeploy' and 'portalClean' attached to the rootProject, but this functionality would be vastly more flexible, maintainable, and idiomatic if it were refactored into a plugin applied to subprojects {} of overlays.

With this approach, you'd not only be able to do...

  $ ./gradlew tomcatDeploy

(which would deploy all the overlays) but also (e.g.)...

  $ ./gradlew :overlays:Announcements:tomcatDeploy

(which would deploy only the one overlay).

Also make sure portalDeploy dependsOn portalClean (which removes the existing webapp from Tomcat).

<!-- Reference Links -->

[individual contributor license agreement]: https://github.com/Jasig/uPortal/blob/master/CONTRIBUTING.md#individual-contributor-license-agreement
[commit guidelines]: https://github.com/Jasig/uPortal/blob/master/CONTRIBUTING.md#commit
[message properties]: https://github.com/Jasig/uPortal/tree/master/uportal-war/src/main/resources/properties/i18n
[WCAG 2.0 AA]: https://www.w3.org/WAI/WCAG20/quickref/?levels=aaa&technologies=smil%2Cpdf%2Cflash%2Csl
