### PR TITLE
UP-4902:  Renamed and switched the portalOpen task to the Portal group

### DIFF
--- a/gradle/tasks/portal.gradle
+++ b/gradle/tasks/portal.gradle
@@ -9,3 +9,12 @@ task portalInit {
     dependsOn allprojects.collect { it.tasks.matching { it.name.equals('tomcatDeploy') } }
     dependsOn allprojects.collect { it.tasks.matching { it.name.equals('dataInit') } }
 }
+
+task portalOpen() {
+   group 'Portal'
+   description 'Opens the Default URL in a browser'
+
+   doLast {
+      java.awt.Desktop.desktop.browse 'http://localhost:8080/uPortal/'.toURI()
+   }
+}

--- a/gradle/tasks/tomcat.gradle
+++ b/gradle/tasks/tomcat.gradle
@@ -19,15 +19,6 @@ dependencies {
     shared "${portletApiDependency}"
 }
 
-task openDefaultUrlInBrowser() {
-   group 'Tomcat'
-   description 'Opens the Default URL in a browser'
-
-   doLast {
-      java.awt.Desktop.desktop.browse 'http://localhost:8080/uPortal/'.toURI()
-   }
-}
-
 task tomcatInstall() {
     description 'Downloads the Apache Tomcat servlet container and performs the necessary configuration steps'
 


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.

Bug fixes and new features should be reported on the issue tracker: https://issues.jasig.org/browse/UP/

Contributors guide: https://github.com/Jasig/uPortal/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

-   [ ] the [individual contributor license agreement][] is signed
-   [ ] commit message follows [commit guidelines][]
-   [ ] documentation is changed or added

##### Description of change
<!-- Provide a description of the change below this comment. -->
Renamed task openDefaultUrlInBrowser to portalOpen and moved to the Portal group

<!-- Reference Links -->

[individual contributor license agreement]: https://github.com/Jasig/uPortal/blob/master/CONTRIBUTING.md#individual-contributor-license-agreement
[commit guidelines]: https://github.com/Jasig/uPortal/blob/master/CONTRIBUTING.md#commit
[message properties]: https://github.com/Jasig/uPortal/tree/master/uportal-war/src/main/resources/properties/i18n
[WCAG 2.0 AA]: https://www.w3.org/WAI/WCAG20/quickref/?levels=aaa&technologies=smil%2Cpdf%2Cflash%2Csl
