### PR TITLE
UP-4888:  Support differentiation between server.home and server.base

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,4 +1,4 @@
-import org.gradle.internal.os.OperatingSystem;
+import org.gradle.internal.os.OperatingSystem
 
 ext {
     /*

--- a/build.properties.sample
+++ b/build.properties.sample
@@ -26,10 +26,20 @@
 # Use forward slashes for path names even if
 # you are in a Windows environment!
 #
+# IMPORTANT!  If you modify the value of either server.home or server.base, it is likely you will
+# want to modify the other value as well.  The default value of server.base is NOT calculated from
+# server.home.
 
-# Location of the integrated Tomcat installation; e.g. server.home=${env.CATALINA_HOME}
+# Location of the integrated Tomcat installation; e.g. server.home=${env.CATALINA_HOME}.  This
+# property corresponds with the ${catalina.home} property within Tomcat (see Tomcat/bin/catalina.sh).
 #
 #server.home=
+
+# (Optional) Base directory for resolving dynamic portions of the integrated Tomcat installation.
+# This property corresponds with the ${catalina.base} property within Tomcat (see
+# Tomcat/bin/catalina.sh).
+#
+#server.base=
 
 # Location of Base Data Set;  base data is imported before entities specified
 # in implementation.entities.location (below) and does not commonly require

--- a/buildSrc/src/main/groovy/org/apereo/portal/start/gradle/plugins/GradleTomcatDeployPlugin.groovy
+++ b/buildSrc/src/main/groovy/org/apereo/portal/start/gradle/plugins/GradleTomcatDeployPlugin.groovy
@@ -12,8 +12,8 @@ class GradleTomcatDeployPlugin implements Plugin<Project> {
             description 'Removes this project from the integrated Tomcat servlet container'
 
             doFirst {
-                File serverHome = new File(project.rootProject.projectDir, project.rootProject.ext['buildProperties'].getProperty('server.home'))
-                File deployDir = new File (serverHome, "webapps/${project.name}")
+                File serverBase = new File(project.rootProject.projectDir, project.rootProject.ext['buildProperties'].getProperty('server.base'))
+                File deployDir = new File (serverBase, "webapps/${project.name}")
                 logger.lifecycle("Removing deployed application from servlet container at location:  ${deployDir}")
                 delete deployDir
             }
@@ -25,8 +25,8 @@ class GradleTomcatDeployPlugin implements Plugin<Project> {
             dependsOn 'assemble'
 
             doFirst {
-                File serverHome = new File(project.rootProject.projectDir, project.rootProject.ext['buildProperties'].getProperty('server.home'))
-                File deployDir = new File (serverHome, "webapps/${project.name}")
+                File serverBase = new File(project.rootProject.projectDir, project.rootProject.ext['buildProperties'].getProperty('server.base'))
+                File deployDir = new File (serverBase, "webapps/${project.name}")
                 logger.lifecycle("Deploying assembled application to servlet container at location:  ${deployDir}")
 
                 String artifactDir = project.plugins.hasPlugin(GradlePlutoPlugin) ? 'pluto' : 'libs'

--- a/buildSrc/src/main/resources/buildDefaults.properties
+++ b/buildSrc/src/main/resources/buildDefaults.properties
@@ -27,9 +27,16 @@
 # you are in a Windows environment!
 #
 
-# Location of the integrated Tomcat installation; e.g. server.home=${env.CATALINA_HOME}
+# Location of the integrated Tomcat installation; e.g. server.home=${env.CATALINA_HOME}.  This
+# property corresponds with the ${catalina.home} property within Tomcat (see Tomcat/bin/catalina.sh).
 #
 server.home=.gradle/tomcat
+
+# (Optional) Base directory for resolving dynamic portions of the integrated Tomcat installation.
+# This property corresponds with the ${catalina.base} property within Tomcat (see
+# Tomcat/bin/catalina.sh).
+#
+server.base=.gradle/tomcat
 
 # Location of Base Data Set;  base data is imported before entities specified
 # in implementation.entities.location (below) and does not commonly require

--- a/gradle/tasks/tomcat.gradle
+++ b/gradle/tasks/tomcat.gradle
@@ -130,8 +130,8 @@ task tomcatClearLogs(type: Delete) {
     description 'Delete all log files within Tomcat'
 
     doFirst {
-        String serverHome = rootProject.ext['buildProperties'].getProperty('server.home')
-        FileTree logsFolder = fileTree("${serverHome}/logs")
+        String serverBase = rootProject.ext['buildProperties'].getProperty('server.base')
+        FileTree logsFolder = fileTree("${serverBase}/logs")
         if (logsFolder.isEmpty()) {
             logger.lifecycle('The Tomcat logs directory is empty;  there is noting to delete')
         } else {


### PR DESCRIPTION
https://issues.jasig.org/browse/UP-4888

This is a reboot of https://github.com/Jasig/uPortal-start/pull/24 by @markamace1;  it includes his 2 commits.

<!--
Thank you for your pull request. Please review below requirements.

Bug fixes and new features should be reported on the issue tracker: https://issues.jasig.org/browse/UP/

Contributors guide: https://github.com/Jasig/uPortal/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

-   [x] the [individual contributor license agreement][] is signed
-   [x] commit message follows [commit guidelines][]
-   [x] documentation is changed or added

##### Description of change
<!-- Provide a description of the change below this comment. -->


<!-- Reference Links -->

[individual contributor license agreement]: https://github.com/Jasig/uPortal/blob/master/CONTRIBUTING.md#individual-contributor-license-agreement
[commit guidelines]: https://github.com/Jasig/uPortal/blob/master/CONTRIBUTING.md#commit
[message properties]: https://github.com/Jasig/uPortal/tree/master/uportal-war/src/main/resources/properties/i18n
[WCAG 2.0 AA]: https://www.w3.org/WAI/WCAG20/quickref/?levels=aaa&technologies=smil%2Cpdf%2Cflash%2Csl
