### PR TITLE
UP-4910:  Introduce the 'portal.home' system property in the sample s…

### DIFF
--- a/etc/tomcat/bin/setenv.bat
+++ b/etc/tomcat/bin/setenv.bat
@@ -8,3 +8,10 @@ set CATALINA_OPTS=%CATALINA_OPTS% -Xmx512m
 
 rem Prevent "Unrecognized Name" SSL warning
 set CATALINA_OPTS=%CATALINA_OPTS% -Djsse.enableSNIExtension=false
+
+rem We need to send a 'portal.home' system property to the JVM;  use the value of PORTAL_HOME, if
+rem present, or fall back to a value calculated from %CATALINA_BASE%
+if not "%PORTAL_HOME%" == "" goto gotPortalHome
+set "PORTAL_HOME=%CATALINA_BASE%\portal"
+:gotPortalHome
+set CATALINA_OPTS=%CATALINA_OPTS% -Dportal.home=%PORTAL_HOME%

--- a/etc/tomcat/bin/setenv.sh
+++ b/etc/tomcat/bin/setenv.sh
@@ -8,3 +8,9 @@ CATALINA_OPTS="$CATALINA_OPTS -Xmx512m"
 
 # Prevent "Unrecognized Name" SSL warning
 CATALINA_OPTS="$CATALINA_OPTS -Djsse.enableSNIExtension=false"
+
+# We need to send a 'portal.home' system property to the JVM;  use the value of PORTAL_HOME, if
+# present, or fall back to a value calculated from $CATALINA_BASE
+[ -z "$PORTAL_HOME" ] && PORTAL_HOME="$CATALINA_BASE/portal"
+echo "PORTAL_HOME=$PORTAL_HOME"
+CATALINA_OPTS="$CATALINA_OPTS -Dportal.home=$PORTAL_HOME"


### PR DESCRIPTION
…etenv.sh and setenv.bat files for Tomcat;  in uPortal, we can use this value to find the location of (optional) configuration files we want to source into the Spring Environment

https://issues.jasig.org/browse/UP-4910

<!--
Thank you for your pull request. Please review below requirements.

Bug fixes and new features should be reported on the issue tracker: https://issues.jasig.org/browse/UP/

Contributors guide: https://github.com/Jasig/uPortal/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

-   [x] the [individual contributor license agreement][] is signed
-   [x] commit message follows [commit guidelines][]

##### Description of change
<!-- Provide a description of the change below this comment. -->

This change adds the `portal.home` system property, provided you use the sample `setenv.sh` (*nix) or `setenv.bat` (Windows).  This is one piece of the puzzle;  we're looking at using `portal.home` to calculate the location of (optional) deployment-specific properties files.

<!-- Reference Links -->

[individual contributor license agreement]: https://github.com/Jasig/uPortal/blob/master/CONTRIBUTING.md#individual-contributor-license-agreement
[commit guidelines]: https://github.com/Jasig/uPortal/blob/master/CONTRIBUTING.md#commit
[message properties]: https://github.com/Jasig/uPortal/tree/master/uportal-war/src/main/resources/properties/i18n
[WCAG 2.0 AA]: https://www.w3.org/WAI/WCAG20/quickref/?levels=aaa&technologies=smil%2Cpdf%2Cflash%2Csl
