### PR TITLE
UP-4873:  New Gradle build -- choose, implement, and document a repla…

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,7 @@ running the following command:
   - [How To Deploy uPortal Technology to Tomcat](#how-to-deploy-uportal-technology-to-tomcat)
   - [How To Create and Initialize the Database Schema](#how-to-create-and-initialize-the-database-schema)
   - [How To Start Tomcat](#how-to-start-tomcat)
+  - [How To Configure Your Deployment](#how-to-configure-your-deployment)
 
 ### How To Set Up Everything the First Time
 
@@ -216,6 +217,31 @@ Assuming all the defaults were left:
 * The default tomcat install is:  _uPortal-start/.gradle/tomcat_
 * The logs to watch for issues are located in:  _uPortal-start/.gradle/tomcat/logs_
 
+### How To Configure Your Deployment
+
+uPortal contains many configuration settings.  (Please refer to the [uPortal 5.0 Manual][] for a
+comprehensive guide to configuration.)  All settings have default values, which  -- for the most
+part -- have been selected to suit the needs of a local development environment (like the one this
+`README` guides you through creating).
+
+You can _override_ the value of most configuration settings using one or both of the following local
+configuration files:
+
+  - `uPortal.properties`
+  - `global.properties`
+
+Both files are optional.  `uPortal.properties` is for _uPortal-only_ settings, whereas
+`global.properties` is for settings that may also be read and used by _uPortal Modules_ (such as
+portlets).  Both files support all the same settings.  If the same setting is defined in both
+files, the value in `uPortal.properties` "wins."
+
+Both files (if you're using them) must be placed in the `portal.home` directory.  The default
+location of `portal.home` is '`${catalina.base}`/portal', but you can specify your own location by
+defining a `PORTAL_HOME` environment variable.
+
+A sample `uPortal.properties` file -- with several commonly-adjusted settings defined and
+documented -- is available in the `etc/portal` directory of this project.  Feel free to customize
+that sample with institution-specific defaults in your fork of uPortal-start.
 
 [Apereo uPortal]: https://www.apereo.org/projects/uportal
 [uPortal 5.0 Manual]: https://jasig.github.io/uPortal

--- a/etc/portal/uPortal.properties
+++ b/etc/portal/uPortal.properties
@@ -34,12 +34,13 @@
 ##   ## Comment line 2, etc
 ##   ##                     <-- (leave a blank commented line)
 ##   property_name=property_value
-##                          <-- (leave two blank
-##                          <--  uncommented lines)
+##                          <-- (leave a blank line...
+##                          <--  or two blank lines before a new section)
 ##
 ## Leave properties that you do not wish to overrride commented-out with a single '#' and set to
-## the default value.
+## the default value (for reference).
 ##
+
 
 ################################################################################
 ##                                                                            ##
@@ -48,8 +49,22 @@
 ################################################################################
 
 ##
+## Portal Server
+##
+#portal.protocol=http
+#portal.server=localhost:8080
+#portal.context=/uPortal
+
+##
 ## Central Authentication Service (CAS)
 ##
+#cas.protocol=http
+#cas.server=localhost:8080
+#cas.context=/cas
+#cas.ticketValidationFilter.service=${portal.protocol}://${portal.server}${portal.context}/Login
+#cas.ticketValidationFilter.proxyReceptorUrl=/CasProxyServlet
+#cas.ticketValidationFilter.ticketValidator.server=${cas.protocol}://${cas.server}${cas.context}
+#cas.ticketValidationFilter.ticketValidator.proxyCallbackUrl=${portal.protocol}://${portal.server}${portal.context}/CasProxyServlet
 #org.apereo.portal.security.provider.cas.CasAssertionSecurityContextFactory.enabled:true
 #org.apereo.portal.security.provider.cas.CasAssertionSecurityContextFactory.credentialToken:ticket
 
@@ -73,9 +88,15 @@
 #org.apereo.portal.security.provider.SimpleSecurityContextFactory.credentialToken:password
 
 ##
+## Destination of the Sign On button
+##
+#org.apereo.portal.channels.CLogin.CasLoginUrl=${cas.protocol}://${cas.server}${cas.context}/login?service=${portal.protocol}://${portal.server}${portal.context}/Login
+
+##
 ## Where should users be redirected when they log out?
 ##
-#logout.redirect=http://localhost:8080/cas/logout?url=http://localhost:8080/uPortal/Login
+#logout.redirect=${cas.protocol}://${cas.server}${cas.context}/logout?url=${portal.protocol}://${portal.server}${portal.context}/Login
+
 
 ################################################################################
 ##                                                                            ##
@@ -88,6 +109,7 @@
 ## applicable).  This property should be set to different value, at least in server deployments.
 ##
 #org.apereo.portal.portlets.passwordEncryptionKey=changeme
+
 
 ################################################################################
 ##                                                                            ##

--- a/etc/portal/uPortal.properties
+++ b/etc/portal/uPortal.properties
@@ -1,0 +1,106 @@
+#
+# Licensed to Apereo under one or more contributor license
+# agreements. See the NOTICE file distributed with this work
+# for additional information regarding copyright ownership.
+# Apereo licenses this file to you under the Apache License,
+# Version 2.0 (the "License"); you may not use this file
+# except in compliance with the License.  You may obtain a
+# copy of the License at the following location:
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+##
+## uPortal.properties
+## ------------------
+##
+## Use this file to override the default values of configuration settings.  All settings in the
+## portal have a default value baked-into the build.  These defaults are suitable for a local
+## development environment.  Place a copy of this file in your ${portal.home} directory and edit to
+## taste.  The default value of ${portal.home} is '${catalina.base}/portal', but you can choose
+## your own location by setting a PORTAL_HOME environment variable.
+##
+## Please keep the formatting of this properties file as follows:
+##
+##   ##
+##   ## Comment line 1
+##   ## Comment line 2, etc
+##   ##                     <-- (leave a blank commented line)
+##   property_name=property_value
+##                          <-- (leave two blank
+##                          <--  uncommented lines)
+##
+## Leave properties that you do not wish to overrride commented-out with a single '#' and set to
+## the default value.
+##
+
+################################################################################
+##                                                                            ##
+##                               Authentication                               ##
+##                                                                            ##
+################################################################################
+
+##
+## Central Authentication Service (CAS)
+##
+#org.apereo.portal.security.provider.cas.CasAssertionSecurityContextFactory.enabled:true
+#org.apereo.portal.security.provider.cas.CasAssertionSecurityContextFactory.credentialToken:ticket
+
+##
+## Remote User (Shibboleth, etc.)
+##
+#org.apereo.portal.security.provider.RemoteUserSecurityContextFactory.enabled:false
+
+##
+## LDAP
+##
+#org.apereo.portal.security.provider.SimpleLdapSecurityContextFactory.enabled:false
+#org.apereo.portal.security.provider.SimpleLdapSecurityContextFactory.principalToken:userName
+#org.apereo.portal.security.provider.SimpleLdapSecurityContextFactory.credentialToken:password
+
+##
+## Simple (database)
+##
+#org.apereo.portal.security.provider.SimpleSecurityContextFactory.enabled:false
+#org.apereo.portal.security.provider.SimpleSecurityContextFactory.principalToken:userName
+#org.apereo.portal.security.provider.SimpleSecurityContextFactory.credentialToken:password
+
+##
+## Where should users be redirected when they log out?
+##
+#logout.redirect=http://localhost:8080/cas/logout?url=http://localhost:8080/uPortal/Login
+
+################################################################################
+##                                                                            ##
+##                                  Security                                  ##
+##                                                                            ##
+################################################################################
+
+##
+## Encryption key for the String Encryption Service used for user password encryption (if
+## applicable).  This property should be set to different value, at least in server deployments.
+##
+#org.apereo.portal.portlets.passwordEncryptionKey=changeme
+
+################################################################################
+##                                                                            ##
+##                                  Soffits                                   ##
+##                                                                            ##
+################################################################################
+
+## Key for signing JSON Web Tokens (JWTs) in Soffits.  This property should be changed to an
+## institution- or environment-specific value.
+##
+#org.apereo.portal.soffit.jwt.signatureKey=CHANGEME
+
+## Key for encrypting JSON Web Tokens (JWTs) in Soffits.  This property should be changed to an
+## institution- or environment-specific value.
+##
+#org.apereo.portal.soffit.jwt.encryptionPassword=CHANGEME

--- a/gradle/tasks/tomcat.gradle
+++ b/gradle/tasks/tomcat.gradle
@@ -20,6 +20,7 @@ dependencies {
 }
 
 task tomcatInstall() {
+    group 'Tomcat'
     description 'Downloads the Apache Tomcat servlet container and performs the necessary configuration steps'
 
     doLast {


### PR DESCRIPTION
…cement for what Maven Filters used to do

https://issues.jasig.org/browse/UP-4873

<!--
Thank you for your pull request. Please review below requirements.

Bug fixes and new features should be reported on the issue tracker: https://issues.jasig.org/browse/UP/

Contributors guide: https://github.com/Jasig/uPortal/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

-   [x] the [individual contributor license agreement][] is signed
-   [x] commit message follows [commit guidelines][]
-   [x] documentation is changed or added

##### Description of change
<!-- Provide a description of the change below this comment. -->

We are moving away from Maven Filters, which "baked" environment-specific settings into the project as it builds.  (This paradigm requires you to build for every environment.)  We intend to provide a way to configure these things externally.

<!-- Reference Links -->

[individual contributor license agreement]: https://github.com/Jasig/uPortal/blob/master/CONTRIBUTING.md#individual-contributor-license-agreement
[commit guidelines]: https://github.com/Jasig/uPortal/blob/master/CONTRIBUTING.md#commit
[message properties]: https://github.com/Jasig/uPortal/tree/master/uportal-war/src/main/resources/properties/i18n
[WCAG 2.0 AA]: https://www.w3.org/WAI/WCAG20/quickref/?levels=aaa&technologies=smil%2Cpdf%2Cflash%2Csl
