### PR TITLE
UP-4920

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,6 +147,12 @@ You can stop the HSQLDB instance with the following command:
     $ ./gradlew hsqlStop
 ```
 
+You can launch the HSQL DB Manager application with the following command:
+
+```console
+    $ ./gradlew hsqlOpen
+```
+
 ### How To Deploy uPortal Technology to Tomcat
 
 When(ever) you perform the `tomcatInstall` task, the Tomcat container will be empty.  You need to

--- a/gradle/tasks/hsql.gradle
+++ b/gradle/tasks/hsql.gradle
@@ -44,6 +44,35 @@ task hsqlStart {
     }
 }
 
+
+task hsqlOpen {
+    group 'HSQL'
+    description 'Launch the HSQL Database Manager connected to the default HSQL database'
+
+    doLast {
+        logger.lifecycle('Starting the HSQLDB Database Manager, connected to the default HSQL database [uPortal]')
+
+        String classpathSeparatorCharacter = isWindows ? ';' : ':'
+        String classpath = '';
+        configurations.hsqldb.resolve().each {
+            if (classpath.length() != 0) {
+                classpath += classpathSeparatorCharacter
+            }
+            classpath += it.getAbsolutePath()
+        }
+
+        ant.exec(executable: 'java', spawn: true) {
+            arg(value: '-cp')
+            arg(value: classpath)
+            arg(value: 'org.hsqldb.util.DatabaseManagerSwing')
+            arg(value: '--url')
+            arg(value: 'jdbc:hsqldb:hsql://localhost:8887/uPortal')
+            arg(value: '--user')
+            arg(value: 'SA')
+        }
+    }
+}
+
 task hsqlStop {
     group 'HSQL'
     description 'Stop the embedded hsql server'


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.

Bug fixes and new features should be reported on the issue tracker: https://issues.jasig.org/browse/UP/

Contributors guide: https://github.com/Jasig/uPortal/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

-   [x] the [individual contributor license agreement][] is signed
-   [x] commit message follows [commit guidelines][]
-   [ ] tests are included
  -  N/A
-   [x] documentation is changed or added
-   [ ] [message properties][] have been updated with new phrases
  -  N/A
-  [ ] view conforms with [WCAG 2.0 AA][]
  -  N/A

##### Description of change
<!-- Provide a description of the change below this comment. -->
Added the hsqlOpen task which launches the HSQL Database Manager, pre-connected to the default uPortal database.

<!-- Reference Links -->

[individual contributor license agreement]: https://github.com/Jasig/uPortal/blob/master/CONTRIBUTING.md#individual-contributor-license-agreement
[commit guidelines]: https://github.com/Jasig/uPortal/blob/master/CONTRIBUTING.md#commit
[message properties]: https://github.com/Jasig/uPortal/tree/master/uportal-war/src/main/resources/properties/i18n
[WCAG 2.0 AA]: https://www.w3.org/WAI/WCAG20/quickref/?levels=aaa&technologies=smil%2Cpdf%2Cflash%2Csl
