### PR TITLE
Choose a 'portal.home' and pass it as a JVM arg to all the Java proce…

### DIFF
--- a/buildSrc/src/main/groovy/org/apereo/portal/start/shell/PortalShellInvoker.groovy
+++ b/buildSrc/src/main/groovy/org/apereo/portal/start/shell/PortalShellInvoker.groovy
@@ -19,6 +19,7 @@ class PortalShellInvoker {
                     pathelement(location: it.absolutePath)
                 }
             }
+            sysproperty(key: 'portal.home', value: project.rootProject.ext['buildProperties'].getProperty('portal.home'))
             sysproperty(key: 'logback.configurationFile', value: 'command-line.logback.xml')
             sysproperty(key: 'java.awt.headless', value: 'true')
             arg(value: '-s')

--- a/gradle/tasks/properties.gradle
+++ b/gradle/tasks/properties.gradle
@@ -47,6 +47,19 @@ def loadBuildProperties = {
     }
 
     /*
+     * And lastly, we MUST have a 'portal.home' property.  That can happen in the following ways
+     * (listed in order of priority):
+     *
+     *   - Already defined (build.properties or a JVM argument)
+     *   - Value of the PORTAL_HOME environment variable
+     *   - The uPortal default, which is "${server.base}/portal"
+     */
+    if (!buildProperties.containsKey('portal.home')) {
+        String portalHome = System.getenv('PORTAL_HOME') ?: "${buildProperties.getProperty('server.base')}/portal"
+        buildProperties.setProperty('portal.home', portalHome)
+    }
+
+    /*
      * List the complete set of build properties to the console.
      */
     logger.lifecycle('Using the following build properties:')

--- a/overlays/Announcements/build.gradle
+++ b/overlays/Announcements/build.gradle
@@ -40,6 +40,7 @@ dataInit {
                     pathelement(location: it.absolutePath)
                 }
             }
+            sysproperty(key: 'portal.home', value: project.rootProject.ext['buildProperties'].getProperty('portal.home'))
             sysproperty(key: 'log4j.configuration', value: 'command-line.log4j.properties')
         }
     }
@@ -59,6 +60,7 @@ dataInit {
                     pathelement(location: it.absolutePath)
                 }
             }
+            sysproperty(key: 'portal.home', value: project.rootProject.ext['buildProperties'].getProperty('portal.home'))
             sysproperty(key: 'log4j.configuration', value: 'command-line.log4j.properties')
             arg(value: "${implementationEntitiesLocation}")
         }

--- a/overlays/CalendarPortlet/build.gradle
+++ b/overlays/CalendarPortlet/build.gradle
@@ -53,6 +53,7 @@ dataInit {
                     pathelement(location: it.absolutePath)
                 }
             }
+            sysproperty(key: 'portal.home', value: project.rootProject.ext['buildProperties'].getProperty('portal.home'))
             sysproperty(key: 'logback.configurationFile', value: 'command-line.logback.xml')
         }
     }
@@ -72,6 +73,7 @@ dataInit {
                     pathelement(location: it.absolutePath)
                 }
             }
+            sysproperty(key: 'portal.home', value: project.rootProject.ext['buildProperties'].getProperty('portal.home'))
             sysproperty(key: 'logback.configurationFile', value: 'command-line.logback.xml')
             arg(value: 'classpath://org/jasig/portlet/calendar/io/import.crn.xml')
             arg(value: "${implementationEntitiesLocation}")

--- a/overlays/NewsReaderPortlet/build.gradle
+++ b/overlays/NewsReaderPortlet/build.gradle
@@ -53,6 +53,7 @@ dataInit {
                     pathelement(location: it.absolutePath)
                 }
             }
+            sysproperty(key: 'portal.home', value: project.rootProject.ext['buildProperties'].getProperty('portal.home'))
             sysproperty(key: 'logback.configurationFile', value: 'command-line.logback.xml')
         }
     }
@@ -72,6 +73,7 @@ dataInit {
                     pathelement(location: it.absolutePath)
                 }
             }
+            sysproperty(key: 'portal.home', value: project.rootProject.ext['buildProperties'].getProperty('portal.home'))
             sysproperty(key: 'logback.configurationFile', value: 'command-line.logback.xml')
             arg(value: 'classpath://org/jasig/portlet/newsreader/io/import.crn.xml')
             arg(value: "${implementationEntitiesLocation}")

--- a/overlays/SimpleContentPortlet/build.gradle
+++ b/overlays/SimpleContentPortlet/build.gradle
@@ -40,6 +40,7 @@ dataInit {
                     pathelement(location: it.absolutePath)
                 }
             }
+            sysproperty(key: 'portal.home', value: project.rootProject.ext['buildProperties'].getProperty('portal.home'))
             sysproperty(key: 'log4j.configuration', value: 'command-line.log4j.properties')
         }
     }


### PR DESCRIPTION
…ss-based CLI tools

<!--
Thank you for your pull request. Please review below requirements.

Bug fixes and new features should be reported on the issue tracker: https://issues.jasig.org/browse/UP/

Contributors guide: https://github.com/Jasig/uPortal/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

-   [x] the [individual contributor license agreement][] is signed
-   [x] commit message follows [commit guidelines][]

##### Description of change
<!-- Provide a description of the change below this comment. -->

`uPortal-start` works well on local dev deployments, but for it to work on server deployments we will need access to `uPortal.properties`, `global.properties`, and (if applicable) module-specific properties files that live in the `portal.home` directory.

We need to pass `portal.home` as a JVM arg -- just as we do in Tomcat -- so all the `PropertySourcesPlaceholderConfigurer` beans can find these files.

<!-- Reference Links -->

[individual contributor license agreement]: https://github.com/Jasig/uPortal/blob/master/CONTRIBUTING.md#individual-contributor-license-agreement
[commit guidelines]: https://github.com/Jasig/uPortal/blob/master/CONTRIBUTING.md#commit
[message properties]: https://github.com/Jasig/uPortal/tree/master/uportal-war/src/main/resources/properties/i18n
[WCAG 2.0 AA]: https://www.w3.org/WAI/WCAG20/quickref/?levels=aaa&technologies=smil%2Cpdf%2Cflash%2Csl
