### PR TITLE
Set AppDefinition.displayStrategy=sameWindow (instead of DETACHED) fo…

### DIFF
--- a/data/quickstart/portlet-definition/resource-aggregation-administration-launcher.portlet-definition.xml
+++ b/data/quickstart/portlet-definition/resource-aggregation-administration-launcher.portlet-definition.xml
@@ -64,6 +64,11 @@
         <value>/uPortal/p/toggle-resources-aggregation</value>
     </portlet-preference>
     <portlet-preference>
+        <name>AppDefinition.displayStrategy</name>
+        <readOnly>false</readOnly>
+        <value>sameWindow</value>
+    </portlet-preference>
+    <portlet-preference>
         <name>AppDefinition.iconUrl</name>
         <readOnly>false</readOnly>
         <value>/uPortal/media/font-awesome/css-3-logo.png</value>


### PR DESCRIPTION
…r resource-aggregation-administration-launcher (like the other admin launchers)

<!--
Thank you for your pull request. Please review below requirements.

Bug fixes and new features should be reported on the issue tracker: https://issues.jasig.org/browse/UP/

Contributors guide: https://github.com/Jasig/uPortal/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

-   [x] the [individual contributor license agreement][] is signed
-   [x] commit message follows [commit guidelines][]

##### Description of change
<!-- Provide a description of the change below this comment. -->

Somehow this one is missing `AppDefinition.displayStrategy=sameWindow`, which causes it to behave differently from the other admin app-launcher portlets.

<!-- Reference Links -->

[individual contributor license agreement]: https://github.com/Jasig/uPortal/blob/master/CONTRIBUTING.md#individual-contributor-license-agreement
[commit guidelines]: https://github.com/Jasig/uPortal/blob/master/CONTRIBUTING.md#commit
[message properties]: https://github.com/Jasig/uPortal/tree/master/uportal-war/src/main/resources/properties/i18n
[WCAG 2.0 AA]: https://www.w3.org/WAI/WCAG20/quickref/?levels=aaa&technologies=smil%2Cpdf%2Cflash%2Csl
