### PR TITLE
Reference the correct logging configuration file in overlays:SimpleCo…

### DIFF
--- a/overlays/SimpleContentPortlet/build.gradle
+++ b/overlays/SimpleContentPortlet/build.gradle
@@ -41,7 +41,7 @@ dataInit {
                 }
             }
             sysproperty(key: 'portal.home', value: project.rootProject.ext['buildProperties'].getProperty('portal.home'))
-            sysproperty(key: 'log4j.configuration', value: 'command-line.log4j.properties')
+            sysproperty(key: 'logback.configurationFile', value: 'command-line.logback.xml')
         }
     }
 }


### PR DESCRIPTION
…ntentPortlet:dataInit -- command-line.logback.xml, not command-line.log4j.properties

<!--
Thank you for your pull request. Please review below requirements.

Bug fixes and new features should be reported on the issue tracker: https://issues.jasig.org/browse/UP/

Contributors guide: https://github.com/Jasig/uPortal/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

-   [x] the [individual contributor license agreement][] is signed
-   [x] commit message follows [commit guidelines][]

##### Description of change
<!-- Provide a description of the change below this comment. -->

Fix logging configuration file for `overlays:SimpleContentPortlet:dataInit`, which uses logback, not log4j.

(This issue is probably a simple copy-paste error.)

<!-- Reference Links -->

[individual contributor license agreement]: https://github.com/Jasig/uPortal/blob/master/CONTRIBUTING.md#individual-contributor-license-agreement
[commit guidelines]: https://github.com/Jasig/uPortal/blob/master/CONTRIBUTING.md#commit
[message properties]: https://github.com/Jasig/uPortal/tree/master/uportal-war/src/main/resources/properties/i18n
[WCAG 2.0 AA]: https://www.w3.org/WAI/WCAG20/quickref/?levels=aaa&technologies=smil%2Cpdf%2Cflash%2Csl
