### PR TITLE
Better default configuration for AuthN;  this update coordinates with…

### DIFF
--- a/etc/portal/uPortal.properties
+++ b/etc/portal/uPortal.properties
@@ -65,27 +65,27 @@
 #cas.ticketValidationFilter.proxyReceptorUrl=/CasProxyServlet
 #cas.ticketValidationFilter.ticketValidator.server=${cas.protocol}://${cas.server}${cas.context}
 #cas.ticketValidationFilter.ticketValidator.proxyCallbackUrl=${portal.protocol}://${portal.server}${portal.context}/CasProxyServlet
-#org.apereo.portal.security.provider.cas.CasAssertionSecurityContextFactory.enabled:true
-#org.apereo.portal.security.provider.cas.CasAssertionSecurityContextFactory.credentialToken:ticket
+org.apereo.portal.security.provider.cas.CasAssertionSecurityContextFactory.enabled=true
+#org.apereo.portal.security.provider.cas.CasAssertionSecurityContextFactory.credentialToken=ticket
 
 ##
 ## Remote User (Shibboleth, etc.)
 ##
-#org.apereo.portal.security.provider.RemoteUserSecurityContextFactory.enabled:false
+#org.apereo.portal.security.provider.RemoteUserSecurityContextFactory.enabled=false
 
 ##
 ## LDAP
 ##
-#org.apereo.portal.security.provider.SimpleLdapSecurityContextFactory.enabled:false
-#org.apereo.portal.security.provider.SimpleLdapSecurityContextFactory.principalToken:userName
-#org.apereo.portal.security.provider.SimpleLdapSecurityContextFactory.credentialToken:password
+#org.apereo.portal.security.provider.SimpleLdapSecurityContextFactory.enabled=false
+#org.apereo.portal.security.provider.SimpleLdapSecurityContextFactory.principalToken=userName
+#org.apereo.portal.security.provider.SimpleLdapSecurityContextFactory.credentialToken=password
 
 ##
 ## Simple (database)
 ##
-#org.apereo.portal.security.provider.SimpleSecurityContextFactory.enabled:false
-#org.apereo.portal.security.provider.SimpleSecurityContextFactory.principalToken:userName
-#org.apereo.portal.security.provider.SimpleSecurityContextFactory.credentialToken:password
+org.apereo.portal.security.provider.SimpleSecurityContextFactory.enabled=true
+#org.apereo.portal.security.provider.SimpleSecurityContextFactory.principalToken=userName
+#org.apereo.portal.security.provider.SimpleSecurityContextFactory.credentialToken=password
 
 ##
 ## Destination of the Sign On button


### PR DESCRIPTION
… the change in uPortal that all AuthN strategies are configured CLOSED (disabled) by default

<!--
Thank you for your pull request. Please review below requirements.

Bug fixes and new features should be reported on the issue tracker: https://issues.jasig.org/browse/UP/

Contributors guide: https://github.com/Jasig/uPortal/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

-   [x] the [individual contributor license agreement][] is signed
-   [x] commit message follows [commit guidelines][]

##### Description of change
<!-- Provide a description of the change below this comment. -->


<!-- Reference Links -->

[individual contributor license agreement]: https://github.com/Jasig/uPortal/blob/master/CONTRIBUTING.md#individual-contributor-license-agreement
[commit guidelines]: https://github.com/Jasig/uPortal/blob/master/CONTRIBUTING.md#commit
[message properties]: https://github.com/Jasig/uPortal/tree/master/uportal-war/src/main/resources/properties/i18n
[WCAG 2.0 AA]: https://www.w3.org/WAI/WCAG20/quickref/?levels=aaa&technologies=smil%2Cpdf%2Cflash%2Csl
