### PR TITLE
Eliminate the custom 'expandedWar' task;  use the product of 'tomcatD…

### DIFF
--- a/buildSrc/src/main/groovy/org/apereo/portal/start/gradle/plugins/GradleImportExportPlugin.groovy
+++ b/buildSrc/src/main/groovy/org/apereo/portal/start/gradle/plugins/GradleImportExportPlugin.groovy
@@ -8,7 +8,7 @@ class GradleImportExportPlugin implements Plugin<Project> {
     void apply(Project project) {
         project.task('dataInit') {
             group 'Data'
-            dependsOn project.rootProject.tasks.portalProperties, project.tasks.expandedWar
+            dependsOn project.rootProject.tasks.portalProperties, project.tasks.tomcatDeploy
             doFirst {
                 if (project.tasks.dataInit.actions.size() == 1) {
                     logger.lifecycle('No actions have been defined for this task in this project')
@@ -17,7 +17,7 @@ class GradleImportExportPlugin implements Plugin<Project> {
         }
         project.task('dataImport') {
             group 'Data'
-            dependsOn project.rootProject.tasks.portalProperties, project.tasks.expandedWar
+            dependsOn project.rootProject.tasks.portalProperties, project.tasks.tomcatDeploy
             doFirst {
                 if (project.tasks.dataImport.actions.size() == 1) {
                     logger.lifecycle('No actions have been defined for this task in this project')
@@ -26,7 +26,7 @@ class GradleImportExportPlugin implements Plugin<Project> {
         }
         project.task('dataExport') {
             group 'Data'
-            dependsOn project.rootProject.tasks.portalProperties, project.tasks.expandedWar
+            dependsOn project.rootProject.tasks.portalProperties, project.tasks.tomcatDeploy
             doFirst {
                 if (project.tasks.dataExport.actions.size() == 1) {
                     logger.lifecycle('No actions have been defined for this task in this project')
@@ -35,7 +35,7 @@ class GradleImportExportPlugin implements Plugin<Project> {
         }
         project.task('dataDelete') {
             group 'Data'
-            dependsOn project.rootProject.tasks.portalProperties, project.tasks.expandedWar
+            dependsOn project.rootProject.tasks.portalProperties, project.tasks.tomcatDeploy
             doFirst {
                 if (project.tasks.dataDelete.actions.size() == 1) {
                     logger.lifecycle('No actions have been defined for this task in this project')
@@ -44,7 +44,7 @@ class GradleImportExportPlugin implements Plugin<Project> {
         }
         project.task('dataList') {
             group 'Data'
-            dependsOn project.rootProject.tasks.portalProperties, project.tasks.expandedWar
+            dependsOn project.rootProject.tasks.portalProperties, project.tasks.tomcatDeploy
             doFirst {
                 if (project.tasks.dataList.actions.size() == 1) {
                     logger.lifecycle('No actions have been defined for this task in this project')

--- a/buildSrc/src/main/groovy/org/apereo/portal/start/shell/PortalShellInvoker.groovy
+++ b/buildSrc/src/main/groovy/org/apereo/portal/start/shell/PortalShellInvoker.groovy
@@ -9,12 +9,14 @@ import org.gradle.api.Project
 class PortalShellInvoker {
 
     void invoke(Project project, String scriptLocation, String... args) {
+        File serverBase = project.rootProject.file(project.rootProject.ext['buildProperties'].getProperty('server.base'))
+        File deployDir = new File (serverBase, "webapps/${project.name}")
 
         project.ant.setLifecycleLogLevel('INFO')
         project.ant.java(fork: true, failonerror: true, dir: project.rootProject.projectDir, classname: 'org.apereo.portal.shell.PortalShell') {
             classpath {
-                pathelement(location: "${project.buildDir}/${project.name}/WEB-INF/classes")
-                pathelement(location: "${project.buildDir}/${project.name}/WEB-INF/lib/*")
+                pathelement(location: "${deployDir}/WEB-INF/classes")
+                pathelement(location: "${deployDir}/WEB-INF/lib/*")
                 project.configurations.shell.files.each {
                     pathelement(location: it.absolutePath)
                 }

--- a/overlays/Announcements/build.gradle
+++ b/overlays/Announcements/build.gradle
@@ -31,11 +31,14 @@ dataInit {
      * Drop (if present) then create the Hibernate-managed schema.
      */
     doLast {
+        File serverBase = rootProject.file(rootProject.ext['buildProperties'].getProperty('server.base'))
+        File deployDir = new File (serverBase, "webapps/${project.name}")
+
         ant.setLifecycleLogLevel('INFO')
         ant.java(fork: true, failonerror: true, dir: rootProject.projectDir, classname: 'org.jasig.portlet.announcements.SchemaCreator') {
             classpath {
-                pathelement(location: "${project.buildDir}/${project.name}/WEB-INF/classes")
-                pathelement(location: "${project.buildDir}/${project.name}/WEB-INF/lib/*")
+                pathelement(location: "${deployDir}/WEB-INF/classes")
+                pathelement(location: "${deployDir}/WEB-INF/lib/*")
                 project.configurations.impexp.files.each {
                     pathelement(location: it.absolutePath)
                 }
@@ -49,13 +52,15 @@ dataInit {
      * specified by 'implementation.entities.location'.
      */
     doLast {
+        File serverBase = rootProject.file(rootProject.ext['buildProperties'].getProperty('server.base'))
+        File deployDir = new File (serverBase, "webapps/${project.name}")
         String implementationEntitiesLocation = PortalShellInvoker.createGroovySafePath(rootProject.ext['buildProperties'].getProperty('implementation.entities.location'))
 
         ant.setLifecycleLogLevel('INFO')
         ant.java(fork: true, failonerror: true, dir: rootProject.projectDir, classname: 'org.jasig.portlet.announcements.Importer') {
             classpath {
-                pathelement(location: "${project.buildDir}/${project.name}/WEB-INF/classes")
-                pathelement(location: "${project.buildDir}/${project.name}/WEB-INF/lib/*")
+                pathelement(location: "${deployDir}/WEB-INF/classes")
+                pathelement(location: "${deployDir}/WEB-INF/lib/*")
                 project.configurations.impexp.files.each {
                     pathelement(location: it.absolutePath)
                 }

--- a/overlays/CalendarPortlet/build.gradle
+++ b/overlays/CalendarPortlet/build.gradle
@@ -31,6 +31,9 @@ dataInit {
      * Drop (if present) then create the Hibernate-managed schema.
      */
     doLast {
+        File serverBase = rootProject.file(rootProject.ext['buildProperties'].getProperty('server.base'))
+        File deployDir = new File (serverBase, "webapps/${project.name}")
+
         /*
          * The following specifies failonerror=false because it will produce an exception like...
          *
@@ -43,12 +46,11 @@ dataInit {
          * The issue appears to stem from the fact that the CALENDAR_ID column is declared for
          * both subclasses, but differently, in CalendarConfiguration.hbm.xml.
          */
-
         ant.setLifecycleLogLevel('INFO')
         ant.java(fork: true, failonerror: false, dir: rootProject.projectDir, classname: 'org.jasig.portlet.calendar.util.SchemaCreator') {
             classpath {
-                pathelement(location: "${project.buildDir}/${project.name}/WEB-INF/classes")
-                pathelement(location: "${project.buildDir}/${project.name}/WEB-INF/lib/*")
+                pathelement(location: "${deployDir}/WEB-INF/classes")
+                pathelement(location: "${deployDir}/WEB-INF/lib/*")
                 project.configurations.impexp.files.each {
                     pathelement(location: it.absolutePath)
                 }
@@ -62,13 +64,15 @@ dataInit {
      * specified by 'implementation.entities.location'.
      */
     doLast {
+        File serverBase = rootProject.file(rootProject.ext['buildProperties'].getProperty('server.base'))
+        File deployDir = new File (serverBase, "webapps/${project.name}")
         String implementationEntitiesLocation = PortalShellInvoker.createGroovySafePath(rootProject.ext['buildProperties'].getProperty('implementation.entities.location'))
 
         ant.setLifecycleLogLevel('INFO')
         ant.java(fork: true, failonerror: true, dir: rootProject.projectDir, classname: 'org.danann.cernunnos.runtime.Main') {
             classpath {
-                pathelement(location: "${project.buildDir}/${project.name}/WEB-INF/classes")
-                pathelement(location: "${project.buildDir}/${project.name}/WEB-INF/lib/*")
+                pathelement(location: "${deployDir}/WEB-INF/classes")
+                pathelement(location: "${deployDir}/WEB-INF/lib/*")
                 project.configurations.impexp.files.each {
                     pathelement(location: it.absolutePath)
                 }

--- a/overlays/NewsReaderPortlet/build.gradle
+++ b/overlays/NewsReaderPortlet/build.gradle
@@ -31,6 +31,9 @@ dataInit {
      * Drop (if present) then create the Hibernate-managed schema.
      */
     doLast {
+        File serverBase = rootProject.file(rootProject.ext['buildProperties'].getProperty('server.base'))
+        File deployDir = new File (serverBase, "webapps/${project.name}")
+
         /*
          * The following specifies failonerror=false because it will produce an exception like...
          *
@@ -43,12 +46,11 @@ dataInit {
          * The issue appears to stem from the fact that the NEWS_ID column is declared for
          * both subclasses, but differently, in NewsConfiguration.hbm.xml.
          */
-
         ant.setLifecycleLogLevel('INFO')
         ant.java(fork: true, failonerror: false, dir: rootProject.projectDir, classname: 'org.jasig.portlet.newsreader.util.SchemaCreator') {
             classpath {
-                pathelement(location: "${project.buildDir}/${project.name}/WEB-INF/classes")
-                pathelement(location: "${project.buildDir}/${project.name}/WEB-INF/lib/*")
+                pathelement(location: "${deployDir}/WEB-INF/classes")
+                pathelement(location: "${deployDir}/WEB-INF/lib/*")
                 project.configurations.impexp.files.each {
                     pathelement(location: it.absolutePath)
                 }
@@ -62,13 +64,15 @@ dataInit {
      * specified by 'implementation.entities.location'.
      */
     doLast {
+        File serverBase = rootProject.file(rootProject.ext['buildProperties'].getProperty('server.base'))
+        File deployDir = new File (serverBase, "webapps/${project.name}")
         String implementationEntitiesLocation = PortalShellInvoker.createGroovySafePath(rootProject.ext['buildProperties'].getProperty('implementation.entities.location'))
 
         ant.setLifecycleLogLevel('INFO')
         ant.java(fork: true, failonerror: true, dir: rootProject.projectDir, classname: 'org.danann.cernunnos.runtime.Main') {
             classpath {
-                pathelement(location: "${project.buildDir}/${project.name}/WEB-INF/classes")
-                pathelement(location: "${project.buildDir}/${project.name}/WEB-INF/lib/*")
+                pathelement(location: "${deployDir}/WEB-INF/classes")
+                pathelement(location: "${deployDir}/WEB-INF/lib/*")
                 project.configurations.impexp.files.each {
                     pathelement(location: it.absolutePath)
                 }

--- a/overlays/SimpleContentPortlet/build.gradle
+++ b/overlays/SimpleContentPortlet/build.gradle
@@ -31,11 +31,14 @@ dataInit {
      * Drop (if present) then create the Hibernate-managed schema.
      */
     doLast {
+        File serverBase = rootProject.file(rootProject.ext['buildProperties'].getProperty('server.base'))
+        File deployDir = new File (serverBase, "webapps/${project.name}")
+
         ant.setLifecycleLogLevel('INFO')
         ant.java(fork: true, failonerror: true, dir: rootProject.projectDir, classname: 'org.jasig.portlet.attachment.util.SchemaCreator') {
             classpath {
-                pathelement(location: "${project.buildDir}/${project.name}/WEB-INF/classes")
-                pathelement(location: "${project.buildDir}/${project.name}/WEB-INF/lib/*")
+                pathelement(location: "${deployDir}/WEB-INF/classes")
+                pathelement(location: "${deployDir}/WEB-INF/lib/*")
                 project.configurations.impexp.files.each {
                     pathelement(location: it.absolutePath)
                 }

--- a/overlays/build.gradle
+++ b/overlays/build.gradle
@@ -72,18 +72,4 @@ subprojects {
         war tasks.war
     }
 
-    task expandedWar(type: Copy, dependsOn: 'war') {
-        from zipTree("${project.buildDir}/libs/${project.name}.war")
-        into "${buildDir}/${project.name}"
-    }
-
-    /*
-     * Follow the pattern where 'assemble' is the generic task for building artifacts.  This allows
-     * us to develop plugins with simply 'dependsOn assemble' instead of worrying about what sorts
-     * of artifacts they produce. All subproject will have (at least) 'expandedWar';  some
-     * subprojects will also have 'plutoAssemble' (which is made a dependency of 'assemble' by the
-     * plugin).
-     */
-    assemble.dependsOn 'expandedWar'
-
 }


### PR DESCRIPTION
…eploy' instead

<!--
Thank you for your pull request. Please review below requirements.

Bug fixes and new features should be reported on the issue tracker: https://issues.jasig.org/browse/UP/

Contributors guide: https://github.com/Jasig/uPortal/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

-   [x] the [individual contributor license agreement][] is signed
-   [x] commit message follows [commit guidelines][]

##### Description of change
<!-- Provide a description of the change below this comment. -->

Currently we have a custom task called `expandedWar` that produces a complete, un-archived version of each overlay sub-project that implements Import/Export functions.  We use this copy of the built project to spawn the Java processes for `dataInit`, `dataImport`, etc.

These copies are no different from the ones we deploy to Tomcat.  We should simply use those for this purpose.  Advantages..
  - Remove and stop maintaining custom `expandedWar` task
  - Produce slimmer Docker containers (that need to be capable of both serving web pages and Import/Export)

<!-- Reference Links -->

[individual contributor license agreement]: https://github.com/Jasig/uPortal/blob/master/CONTRIBUTING.md#individual-contributor-license-agreement
[commit guidelines]: https://github.com/Jasig/uPortal/blob/master/CONTRIBUTING.md#commit
[message properties]: https://github.com/Jasig/uPortal/tree/master/uportal-war/src/main/resources/properties/i18n
[WCAG 2.0 AA]: https://www.w3.org/WAI/WCAG20/quickref/?levels=aaa&technologies=smil%2Cpdf%2Cflash%2Csl
