### PR TITLE
docs: add code of conduct, referencing Apereo welcoming policy

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,9 @@
+# Code of Conduct
+
+uPortal-start is an Apereo Foundation sponsored project.
+
+The [Apereo Foundation Welcoming Policy][] therefore applies.
+
+In addition to reporting mechanisms under that Policy, participants may at any time contact the uPortal Steering Committee ( `uportal-steering-committee@apereo.org` ) about any matter, and may designate their contact as confidential if they prefer. All contact will be acknowledged. Contacts regarding issues covered by the Welcoming Policy will be handled in a manner consistent with that policy.
+
+[Apereo Foundation Welcoming Policy]: https://www.apereo.org/content/apereo-welcoming-policy


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.

Bug fixes and new features should be reported on the issue tracker: https://issues.jasig.org/browse/UP/

Contributors guide: https://github.com/Jasig/uPortal/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

-   [x] the [individual contributor license agreement][] is signed
-   [x] commit message follows [commit guidelines][]
-   [x] documentation is changed or added

##### Description of change
<!-- Provide a description of the change below this comment. -->

Acknowledges that as a sponsored Apereo project, uPortal is in-scope for Apereo Welcoming Policy, as `CODE_OF_CONDUCT.md`.

Ref: https://github.com/Jasig/uPortal/pull/931

<!-- Reference Links -->

[individual contributor license agreement]: https://github.com/Jasig/uPortal/blob/master/CONTRIBUTING.md#individual-contributor-license-agreement
[commit guidelines]: https://github.com/Jasig/uPortal/blob/master/CONTRIBUTING.md#commit
[message properties]: https://github.com/Jasig/uPortal/tree/master/uportal-war/src/main/resources/properties/i18n
[WCAG 2.0 AA]: https://www.w3.org/WAI/WCAG20/quickref/?levels=aaa&technologies=smil%2Cpdf%2Cflash%2Csl
