### PR TITLE
build(gradle): add plugin that generates a visualization of task graph

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,8 @@
 import org.gradle.internal.os.OperatingSystem
 
 plugins {
+  // Records all tasks in task graph, generates `build/reports/visteg.dot`
+  // dot file can be converted to an image using graphviz. `dot -Tsvg -O -v visteg.dot`
   id 'cz.malohlava' version '1.0.3'
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,9 @@
 import org.gradle.internal.os.OperatingSystem
 
+plugins {
+  id 'cz.malohlava' version '1.0.3'
+}
+
 ext {
     /*
      * We need to define the buildProperties extended property here in order for the


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.

Bug fixes and new features should be reported on the issue tracker: https://issues.jasig.org/browse/UP/

Contributors guide: https://github.com/Jasig/uPortal/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

-   [x] the [individual contributor license agreement][] is signed
-   [x] commit message follows [commit guidelines][]

##### Description of change
<!-- Provide a description of the change below this comment. -->

Every task run will generate a *build/reports/visteg.dot* file.
This file can be converted to svg or png using graphviz `dot -Tsvg visteg.dot -O -v`.

Ref: https://github.com/mmalohlava/gradle-visteg
Example output:

![visteg dot](https://user-images.githubusercontent.com/3107513/31474543-4fce3136-aeb0-11e7-99f1-7fa0e1ac4cc3.png)

<!-- Reference Links -->

[individual contributor license agreement]: https://github.com/Jasig/uPortal/blob/master/CONTRIBUTING.md#individual-contributor-license-agreement
[commit guidelines]: https://github.com/Jasig/uPortal/blob/master/CONTRIBUTING.md#commit
[message properties]: https://github.com/Jasig/uPortal/tree/master/uportal-war/src/main/resources/properties/i18n
[WCAG 2.0 AA]: https://www.w3.org/WAI/WCAG20/quickref/?levels=aaa&technologies=smil%2Cpdf%2Cflash%2Csl
