### PR TITLE
build(gradle): fix portalInit task graph

### DIFF
--- a/buildSrc/src/main/groovy/org/apereo/portal/start/gradle/plugins/GradleTomcatDeployPlugin.groovy
+++ b/buildSrc/src/main/groovy/org/apereo/portal/start/gradle/plugins/GradleTomcatDeployPlugin.groovy
@@ -11,6 +11,7 @@ class GradleTomcatDeployPlugin implements Plugin<Project> {
             group 'Tomcat'
             description 'Removes this project from the integrated Tomcat servlet container'
             dependsOn project.rootProject.tasks.portalProperties
+            mustRunAfter project.rootProject.tasks.tomcatInstall
 
             doFirst {
                 File serverBase = project.rootProject.file(project.rootProject.ext['buildProperties'].getProperty('server.base'))
@@ -39,7 +40,6 @@ class GradleTomcatDeployPlugin implements Plugin<Project> {
                     }
                     into deployDir
                 }
-
             }
         }
     }


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.

Bug fixes and new features should be reported on the issue tracker: https://issues.jasig.org/browse/UP/

Contributors guide: https://github.com/Jasig/uPortal/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

-   [x] the [individual contributor license agreement][] is signed
-   [x] commit message follows [commit guidelines][]

##### Description of change
<!-- Provide a description of the change below this comment. -->

ensures that `tomcatClean` and `tomcatDeploy` happen after tomcat has been installed.
resolves #67 

##### New portalInit

![visteg dot](https://user-images.githubusercontent.com/3107513/31475129-e5791e46-aeb3-11e7-81bc-5717289072cb.png)


<!-- Reference Links -->

[individual contributor license agreement]: https://github.com/Jasig/uPortal/blob/master/CONTRIBUTING.md#individual-contributor-license-agreement
[commit guidelines]: https://github.com/Jasig/uPortal/blob/master/CONTRIBUTING.md#commit
[message properties]: https://github.com/Jasig/uPortal/tree/master/uportal-war/src/main/resources/properties/i18n
[WCAG 2.0 AA]: https://www.w3.org/WAI/WCAG20/quickref/?levels=aaa&technologies=smil%2Cpdf%2Cflash%2Csl
