### PR TITLE
ci(travis): add open jdk 8 to test matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: java
 
 matrix:
-  fast_finish: true
   include:
     - os: linux
       dist: trusty
@@ -12,7 +11,7 @@ matrix:
       jdk: openjdk8
       sudo: required
     - os: osx
-      osx_image: xcode8.3
+      osx_image: xcode9.1 # OSX 10.12, Oracle Java 8
 
 script:
   # test embedded tomcat

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,10 @@ matrix:
       dist: trusty
       sudo: required
       jdk: oraclejdk8
+    - os: linux
+      dist: trusty
+      jdk: openjdk8
+      sudo: required
     - os: osx
       osx_image: xcode8.3
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,8 +4,8 @@ matrix:
   include:
     - os: linux
       dist: trusty
-      sudo: required
       jdk: oraclejdk8
+      sudo: required
     - os: linux
       dist: trusty
       jdk: openjdk8


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.

Bug fixes and new features should be reported on the issue tracker: https://issues.jasig.org/browse/UP/

Contributors guide: https://github.com/Jasig/uPortal/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

-   [x] the [individual contributor license agreement][] is signed
-   [x] commit message follows [commit guidelines][]

##### Description of change
<!-- Provide a description of the change below this comment. -->

Ensures that uPortal also functions with latest OpenJDK version.

<!-- Reference Links -->

[individual contributor license agreement]: https://github.com/Jasig/uPortal/blob/master/CONTRIBUTING.md#individual-contributor-license-agreement
[commit guidelines]: https://github.com/Jasig/uPortal/blob/master/CONTRIBUTING.md#commit
[message properties]: https://github.com/Jasig/uPortal/tree/master/uportal-war/src/main/resources/properties/i18n
[WCAG 2.0 AA]: https://www.w3.org/WAI/WCAG20/quickref/?levels=aaa&technologies=smil%2Cpdf%2Cflash%2Csl
