### PR TITLE
UP-4960: Add feedback navigation portlet to layout

### DIFF
--- a/data/quickstart/fragment-layout/all-lo.fragment-layout.xml
+++ b/data/quickstart/fragment-layout/all-lo.fragment-layout.xml
@@ -43,6 +43,7 @@
         </folder>
         <folder ID="s400" hidden="false" immutable="true" name="Pre Content folder" type="pre-content" unremovable="true">
             <channel fname="tips" unremovable="false" hidden="false" immutable="false" ID="n410"/>
+            <channel fname="feedback-navigation" unremovable="true" hidden="true" immutable="false" ID="n420"/>
         </folder>
         <folder id="s500" hidden="false" immutable="true" name="Legal Footer" type="footer-second" unremovable="true">
             <channel fname="legal-footer" unremovable="true" hidden="false" immutable="false" ID="n510"/>

--- a/data/quickstart/portlet-definition/feedback-navigation.portlet-definition.xml
+++ b/data/quickstart/portlet-definition/feedback-navigation.portlet-definition.xml
@@ -31,7 +31,7 @@
         <ns2:portletName>cms</ns2:portletName>
     </portlet-descriptor>
     <category>Services</category>
-    <group>Everyone</group>
+    <group>Authenticated Users</group>
     <permissions>
         <permission system="UP_PORTLET_SUBSCRIBE" activity="BROWSE">
             <group>Everyone</group>
@@ -77,9 +77,11 @@
         <name>content</name>
         <readOnly>false</readOnly>
         <value>
-            &lt;link rel=&quot;stylesheet&quot; href=&quot;https://fonts.googleapis.com/icon?family=Material+Icons&quot;&gt;
+        <![CDATA[
+            <link rel="stylesheet" href="https://fonts.googleapis.com/icon?family=Material+Icons">
 
-            &lt;div style=&quot;float:right&quot;&gt;&lt;a href=&quot;/uPortal/p/feedback&quot;&gt;Your feedback is important to us!&lt;/a&gt; &lt;i aria-hidden=&quot;true&quot; class=&quot;material-icons&quot; style=&quot;font-size:15px&quot; alt=&quot;Feedback icon&quot;&gt;feedback&lt;/i&gt;&lt;/div&gt;
+            <div style="float:right"><a href="/uPortal/p/feedback">Your feedback is important to us!</a> <i aria-hidden="true" class="material-icons" style="font-size:15px" alt="Feedback icon">feedback</i></div>
+        ]]>
         </value>
     </portlet-preference>
 </portlet-definition>

--- a/data/quickstart/portlet-definition/feedback-navigation.portlet-definition.xml
+++ b/data/quickstart/portlet-definition/feedback-navigation.portlet-definition.xml
@@ -1,0 +1,85 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<!--
+
+    Licensed to Apereo under one or more contributor license
+    agreements. See the NOTICE file distributed with this work
+    for additional information regarding copyright ownership.
+    Apereo licenses this file to you under the Apache License,
+    Version 2.0 (the "License"); you may not use this file
+    except in compliance with the License.  You may obtain a
+    copy of the License at the following location:
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied.  See the License for the
+    specific language governing permissions and limitations
+    under the License.
+
+-->
+<portlet-definition xmlns="https://source.jasig.org/schemas/uportal/io/portlet-definition" xmlns:ns2="https://source.jasig.org/schemas/uportal" xmlns:ns3="https://source.jasig.org/schemas/uportal/io/permission-owner" xmlns:ns4="https://source.jasig.org/schemas/uportal/io/stylesheet-descriptor" xmlns:ns5="https://source.jasig.org/schemas/uportal/io/portlet-type" xmlns:ns6="https://source.jasig.org/schemas/uportal/io/user" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="4.0" xsi:schemaLocation="https://source.jasig.org/schemas/uportal/io/portlet-definition https://source.jasig.org/schemas/uportal/io/portlet-definition/portlet-definition-4.0.xsd">
+    <title>Feedback Navigation</title>
+    <name>Feedback Navigation</name>
+    <fname>feedback-navigation</fname>
+    <desc>User-facing link to give feedback</desc>
+    <type>Portlet</type>
+    <timeout>5000</timeout>
+    <portlet-descriptor>
+        <ns2:webAppName>/SimpleContentPortlet</ns2:webAppName>
+        <ns2:portletName>cms</ns2:portletName>
+    </portlet-descriptor>
+    <category>Services</category>
+    <group>Everyone</group>
+    <permissions>
+        <permission system="UP_PORTLET_SUBSCRIBE" activity="BROWSE">
+            <group>Everyone</group>
+        </permission>
+    </permissions>
+    <parameter>
+        <name>blockImpersonation</name>
+        <value>false</value>
+    </parameter>
+    <parameter>
+        <name>chromeStyle</name>
+        <value>default</value>
+    </parameter>
+    <parameter>
+        <name>configurable</name>
+        <value>false</value>
+    </parameter>
+    <parameter>
+        <name>disableDynamicTitle</name>
+        <value>true</value>
+    </parameter>
+    <parameter>
+        <name>editable</name>
+        <value>false</value>
+    </parameter>
+    <parameter>
+        <name>hasAbout</name>
+        <value>false</value>
+    </parameter>
+    <parameter>
+        <name>hasHelp</name>
+        <value>false</value>
+    </parameter>
+    <parameter>
+        <name>hideFromMobile</name>
+        <value>false</value>
+    </parameter>
+    <parameter>
+        <name>printable</name>
+        <value>false</value>
+    </parameter>
+    <portlet-preference>
+        <name>content</name>
+        <readOnly>false</readOnly>
+        <value>
+            &lt;link rel=&quot;stylesheet&quot; href=&quot;https://fonts.googleapis.com/icon?family=Material+Icons&quot;&gt;
+
+            &lt;div style=&quot;float:right&quot;&gt;&lt;a href=&quot;/uPortal/p/feedback-submit&quot;&gt;Your feedback is important to us!&lt;/a&gt; &lt;i aria-hidden=&quot;true&quot; class=&quot;material-icons&quot; style=&quot;font-size:15px&quot; alt=&quot;Feedback icon&quot;&gt;feedback&lt;/i&gt;&lt;/div&gt;
+        </value>
+    </portlet-preference>
+</portlet-definition>

--- a/data/quickstart/portlet-definition/feedback-navigation.portlet-definition.xml
+++ b/data/quickstart/portlet-definition/feedback-navigation.portlet-definition.xml
@@ -79,7 +79,7 @@
         <value>
             &lt;link rel=&quot;stylesheet&quot; href=&quot;https://fonts.googleapis.com/icon?family=Material+Icons&quot;&gt;
 
-            &lt;div style=&quot;float:right&quot;&gt;&lt;a href=&quot;/uPortal/p/feedback-submit&quot;&gt;Your feedback is important to us!&lt;/a&gt; &lt;i aria-hidden=&quot;true&quot; class=&quot;material-icons&quot; style=&quot;font-size:15px&quot; alt=&quot;Feedback icon&quot;&gt;feedback&lt;/i&gt;&lt;/div&gt;
+            &lt;div style=&quot;float:right&quot;&gt;&lt;a href=&quot;/uPortal/p/feedback&quot;&gt;Your feedback is important to us!&lt;/a&gt; &lt;i aria-hidden=&quot;true&quot; class=&quot;material-icons&quot; style=&quot;font-size:15px&quot; alt=&quot;Feedback icon&quot;&gt;feedback&lt;/i&gt;&lt;/div&gt;
         </value>
     </portlet-preference>
 </portlet-definition>


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.

Bug fixes and new features should be reported on the issue tracker: https://issues.jasig.org/browse/UP/

Contributors guide: https://github.com/Jasig/uPortal/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

-   [x] the [individual contributor license agreement][] is signed
-   [x] commit message follows [commit guidelines][]
-   [] [message properties][] have been updated with new phrases
-   [x] view conforms with [WCAG 2.0 AA][]

##### Description of change
<!-- Provide a description of the change below this comment. -->
Adding new feature to uPortal. It is a portlet, with a helpful reminder to submit feedback and a link to feedback, which is in the layout, specifically all-lo. It is just under the tips portlet.

https://issues.jasig.org/browse/UP-4960

<!-- Reference Links -->

[individual contributor license agreement]: https://github.com/Jasig/uPortal/blob/master/CONTRIBUTING.md#individual-contributor-license-agreement
[commit guidelines]: https://github.com/Jasig/uPortal/blob/master/CONTRIBUTING.md#commit
[message properties]: https://github.com/Jasig/uPortal/tree/master/uportal-war/src/main/resources/properties/i18n
[WCAG 2.0 AA]: https://www.w3.org/WAI/WCAG20/quickref/?levels=aaa&technologies=smil%2Cpdf%2Cflash%2Csl
