### PR TITLE
Add missing '+' character within '-XX:+UseG1GC' inside setenv.bat

### DIFF
--- a/etc/tomcat/bin/setenv.bat
+++ b/etc/tomcat/bin/setenv.bat
@@ -19,7 +19,7 @@ echo.%CATALINA_OPTS%|findstr /C:"-XX:+UseSerialGC" /C:"-XX:+UseParallelGC" /C:"-
 if not errorlevel 1 (
     echo Already declared a garbage collector
 ) else (
-    set CATALINA_OPTS=%CATALINA_OPTS% -XX:UseG1GC
+    set CATALINA_OPTS=%CATALINA_OPTS% -XX:+UseG1GC
 )
 
 rem We need to send a 'portal.home' system property to the JVM;  use the value of PORTAL_HOME, if


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.

Bug fixes and new features should be reported on the issue tracker: https://issues.jasig.org/browse/UP/

Contributors guide: https://github.com/Jasig/uPortal/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

-   [x] the [individual contributor license agreement][] is signed
-   [x] commit message follows [commit guidelines][]

##### Description of change
<!-- Provide a description of the change below this comment. -->

This issue seems to me like something that should be caught in the CI.  I would like it very much if we can enhance the Gradle setup and/or the CI setup so that this kind of thing can be caught.

<!-- Reference Links -->

[individual contributor license agreement]: https://github.com/Jasig/uPortal/blob/master/CONTRIBUTING.md#individual-contributor-license-agreement
[commit guidelines]: https://github.com/Jasig/uPortal/blob/master/CONTRIBUTING.md#commit
[message properties]: https://github.com/Jasig/uPortal/tree/master/uportal-war/src/main/resources/properties/i18n
[WCAG 2.0 AA]: https://www.w3.org/WAI/WCAG20/quickref/?levels=aaa&technologies=smil%2Cpdf%2Cflash%2Csl
