### PR TITLE
build(gradle): enable gradle build cache

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,26 +5,24 @@ matrix:
     - os: linux
       dist: trusty
       jdk: oraclejdk8
-      sudo: required
     - os: linux
       dist: trusty
       jdk: openjdk8
-      sudo: required
     - os: osx
       osx_image: xcode9.1 # OSX 10.12, Oracle Java 8
 
 script:
   # test embedded tomcat
-  - ./gradlew -u -i -S tomcatInstall
-  - ./gradlew -u -i -S tomcatStart
-  - ./gradlew -u -i -S tomcatStop
-  - ./gradlew -u -i -S tomcatClearLogs
+  - ./gradlew -u -i -S --no-daemon --no-parallel --no-build-cache tomcatInstall
+  - ./gradlew -u -i -S --no-daemon --no-parallel --no-build-cache tomcatStart
+  - ./gradlew -u -i -S --no-daemon --no-parallel --no-build-cache tomcatStop
+  - ./gradlew -u -i -S --no-daemon --no-parallel --no-build-cache tomcatClearLogs
   # test HSQL
-  - ./gradlew -u -i -S hsqlStart
-  - ./gradlew -u -i -S dataInit
-  - ./gradlew -u -i -S hsqlStop
+  - ./gradlew -u -i -S --no-daemon --no-parallel --no-build-cache hsqlStart
+  - ./gradlew -u -i -S --no-daemon --no-parallel --no-build-cache dataInit
+  - ./gradlew -u -i -S --no-daemon --no-parallel --no-build-cache hsqlStop
   # test skin generation tool
-  - ./gradlew -u -i -S skinGenerate -DskinName=travis
+  - ./gradlew -u -i -S --no-daemon --no-parallel --no-build-cache skinGenerate -DskinName=travis
 
 cache:
   directories:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -3,22 +3,22 @@ environment:
 os: Visual Studio 2017 # Windows Server 2016
 install:
   - java -version
-  - gradlew.bat --version
+  - gradlew.bat --no-daemon --version
 build: off
 test_script:
   # install and build source
-  - gradlew.bat -u -i -S build
+  - gradlew.bat -u -i -S --no-daemon --no-parallel --no-build-cache build
   # test embedded tomcat
-  - gradlew.bat -u -i -S tomcatInstall
-  - gradlew.bat -u -i -S tomcatStart
-  - gradlew.bat -u -i -S tomcatStop
-  - gradlew.bat -u -i -S tomcatClearLogs
+  - gradlew.bat -u -i -S --no-daemon --no-parallel --no-build-cache tomcatInstall
+  - gradlew.bat -u -i -S --no-daemon --no-parallel --no-build-cache tomcatStart
+  - gradlew.bat -u -i -S --no-daemon --no-parallel --no-build-cache tomcatStop
+  - gradlew.bat -u -i -S --no-daemon --no-parallel --no-build-cache tomcatClearLogs
   # test HSQL
-  - gradlew.bat -u -i -S hsqlStart
-  - gradlew.bat -u -i -S dataInit
-  - gradlew.bat -u -i -S hsqlStop
+  - gradlew.bat -u -i -S --no-daemon --no-parallel --no-build-cache hsqlStart
+  - gradlew.bat -u -i -S --no-daemon --no-parallel --no-build-cache dataInit
+  - gradlew.bat -u -i -S --no-daemon --no-parallel --no-build-cache hsqlStop
   # test skin generation tool
-  - gradlew.bat -u -i -S skinGenerate -DskinName=appveyor
+  - gradlew.bat -u -i -S --no-daemon --no-parallel --no-build-cache skinGenerate -DskinName=appveyor
 cache:
   - .gradle
   - C:\Users\appveyor\.gradle

--- a/gradle.properties
+++ b/gradle.properties
@@ -39,4 +39,6 @@ waroverlayPluginVersion=0.9.3
 xercesImplVersion=2.9.1
 nodejsVersion=8.2.1
 
+# gradle settings
+org.gradle.caching=true
 org.gradle.parallel=true


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.

Bug fixes and new features should be reported on the issue tracker: https://issues.jasig.org/browse/UP/

Contributors guide: https://github.com/Jasig/uPortal/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

-   [x] the [individual contributor license agreement][] is signed
-   [x] commit message follows [commit guidelines][]

##### Description of change
<!-- Provide a description of the change below this comment. -->

> The Gradle build cache is a cache mechanism that aims to save time by reusing outputs produced by other builds. The build cache works by storing (locally or remotely) build outputs and allowing builds to fetch these outputs from the cache when it is determined that inputs have not changed, avoiding the expensive work of regenerating them.

this PR enabled build cache by default for developer builds of uPortal.
However CI will intentionally avoid build cache to ensure a prestine build each time.
Additionally parallel mode has been disabled on CI to ensure logs are readable.

<!-- Reference Links -->

[individual contributor license agreement]: https://github.com/Jasig/uPortal/blob/master/CONTRIBUTING.md#individual-contributor-license-agreement
[commit guidelines]: https://github.com/Jasig/uPortal/blob/master/CONTRIBUTING.md#commit
[message properties]: https://github.com/Jasig/uPortal/tree/master/uportal-war/src/main/resources/properties/i18n
[WCAG 2.0 AA]: https://www.w3.org/WAI/WCAG20/quickref/?levels=aaa&technologies=smil%2Cpdf%2Cflash%2Csl
