### PR TITLE
feat(docker): support building uPortal from Docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,10 @@
+# build uPortal's custom Tomcat
+FROM openjdk:8-jdk-alpine as build
+COPY . .
+RUN ./gradlew tomcatInstall tomcatDeploy --no-daemon
+
+# copy custom Tomcat runtime into minimal Java container
+FROM openjdk:8-jdk-alpine as server
+COPY --from=build .gradle/tomcat .
+CMD ./bin/catalina.sh run
+EXPOSE 8080:8080

--- a/README.md
+++ b/README.md
@@ -267,6 +267,24 @@ A sample `uPortal.properties` file -- with several commonly-adjusted settings de
 documented -- is available in the `etc/portal` directory of this project.  Feel free to customize
 that sample with institution-specific defaults in your fork of uPortal-start.
 
+### Creating a Docker deployment
+
+To create a docker image that can be externally deployed
+
+```console
+./gradlew portalInit dockerBuildImage
+```
+
+will produce an `apereo/uportal:latest` docker image that can be deployed.
+
+### Running docker locally
+
+```console
+./gradlew portalInit dockerCreateContainer dockerStart
+```
+
+will create and start a local uPortal docker container.
+
 [Apereo uPortal]: https://www.apereo.org/projects/uportal
 [uPortal 5.0 Manual]: https://jasig.github.io/uPortal
 [Java Development Kit]: http://www.oracle.com/technetwork/java/javase/downloads/index.html

--- a/build.gradle
+++ b/build.gradle
@@ -1,9 +1,13 @@
 import org.gradle.internal.os.OperatingSystem
+import com.bmuschko.gradle.docker.tasks.image.*
 
 plugins {
-  // Records all tasks in task graph, generates `build/reports/visteg.dot`
-  // dot file can be converted to an image using graphviz. `dot -Tsvg -O -v visteg.dot`
-  id 'cz.malohlava' version '1.0.3'
+    // Records all tasks in task graph, generates `build/reports/visteg.dot`
+    // dot file can be converted to an image using graphviz. `dot -Tsvg -O -v visteg.dot`
+    id 'cz.malohlava' version '1.0.3'
+
+    // This requires docker to be installed and for Gradle to have access to the docker process
+    id 'com.bmuschko.docker-remote-api' version '3.2.2'
 }
 
 ext {
@@ -32,3 +36,70 @@ apply from: rootProject.file('gradle/tasks/hsql.gradle')
 apply from: rootProject.file('gradle/tasks/portal.gradle')
 apply from: rootProject.file('gradle/tasks/portlet.gradle')
 apply from: rootProject.file('gradle/tasks/tomcat.gradle')
+
+import com.bmuschko.gradle.docker.tasks.image.DockerBuildImage
+import com.bmuschko.gradle.docker.tasks.container.DockerRemoveContainer
+import com.bmuschko.gradle.docker.tasks.container.DockerCreateContainer
+import com.bmuschko.gradle.docker.tasks.container.DockerStartContainer
+import com.bmuschko.gradle.docker.tasks.container.DockerStopContainer
+
+task dockerGradleClean(type: Delete) {
+  group 'Docker'
+  description 'Clear Gradle artifacts that are not stored in the build folder'
+  delete '.gradle'
+  delete 'overlays/uPortal/.gradle'
+  delete 'overlays/uPortal/node_modules'
+}
+
+task dockerBuildImage(type: DockerBuildImage) {
+    dependsOn getTasksByName('clean', true)
+    dependsOn dockerGradleClean
+
+    group 'Docker'
+    description 'Builds a docker image'
+
+    inputDir = file('.')
+    tag = 'apereo/uportal:latest'
+}
+
+task dockerRemoveContainer(type: DockerRemoveContainer) {
+    group 'Docker'
+    description 'Removes existing local docker container'
+
+    targetContainerId { 'uportal-local' }
+    onError { exception ->
+        // ignore exception if container does not exist otherwise throw it
+        if (!exception.message.contains('No such container'))
+            throw exception
+    }
+}
+
+task dockerCreateContainer(type: DockerCreateContainer) {
+    dependsOn dockerBuildImage
+    dependsOn dockerRemoveContainer
+
+    group 'Docker'
+    description 'Builds a local docker container'
+
+    targetImageId { dockerBuildImage.getImageId() }
+    containerName 'uportal-local'
+}
+
+task dockerStart(type: DockerStartContainer) {
+    mustRunAfter dockerCreateContainer
+
+    group 'Docker'
+    description 'Starts local uPortal docker container'
+
+    targetContainerId { 'uportal-local' }
+}
+
+task dockerStop(type: DockerStopContainer) {
+    mustRunAfter dockerCreateContainer
+    mustRunAfter dockerStart
+
+    group 'Docker'
+    description 'Stops local uPortal docker container'
+
+    targetContainerId { 'uportal-local' }
+}


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.

Bug fixes and new features should be reported on the issue tracker: https://issues.jasig.org/browse/UP/

Contributors guide: https://github.com/Jasig/uPortal/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

-   [x] the [individual contributor license agreement][] is signed
-   [x] commit message follows [commit guidelines][]
-   [x] documentation is changed or added

##### Description of change
<!-- Provide a description of the change below this comment. -->

Based off #62, this offers an alternative Docker approach to #102 

In this setup:

1. Gradle starts a Docker build process
2. The Docker build container installs its own gradle and builds the project
3. The Docker server container copies the built code from the build container, and creates an image
4. *optional* generate a local container based of uPortal image
5. *optional* start and stop local docker container

---

This has the advantage that Java and Gradle do not need to be installed locally.
The entire build and deploy process can be handled with Docker.

<!-- Reference Links -->

[individual contributor license agreement]: https://github.com/Jasig/uPortal/blob/master/CONTRIBUTING.md#individual-contributor-license-agreement
[commit guidelines]: https://github.com/Jasig/uPortal/blob/master/CONTRIBUTING.md#commit
[message properties]: https://github.com/Jasig/uPortal/tree/master/uportal-war/src/main/resources/properties/i18n
[WCAG 2.0 AA]: https://www.w3.org/WAI/WCAG20/quickref/?levels=aaa&technologies=smil%2Cpdf%2Cflash%2Csl
