### PR TITLE
feat: wait for server ports to come online, announce when tomcat is ready

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -31,6 +31,6 @@ apply from: rootProject.file('gradle/tasks/properties.gradle')
  * uPortal CLI Tools
  */
 apply from: rootProject.file('gradle/tasks/hsql.gradle')
+apply from: rootProject.file('gradle/tasks/tomcat.gradle')
 apply from: rootProject.file('gradle/tasks/portal.gradle')
 apply from: rootProject.file('gradle/tasks/portlet.gradle')
-apply from: rootProject.file('gradle/tasks/tomcat.gradle')

--- a/build.gradle
+++ b/build.gradle
@@ -4,6 +4,8 @@ plugins {
   // Records all tasks in task graph, generates `build/reports/visteg.dot`
   // dot file can be converted to an image using graphviz. `dot -Tsvg -O -v visteg.dot`
   id 'cz.malohlava' version '1.0.3'
+
+  id 'build-announcements'
 }
 
 ext {

--- a/gradle/tasks/hsql.gradle
+++ b/gradle/tasks/hsql.gradle
@@ -42,6 +42,10 @@ task hsqlStart {
             arg(value: '--port')
             arg(value: '8887')
         }
+
+        ant.waitfor() {
+            socket(server: 'localhost', port: 8887)
+        }
     }
 }
 
@@ -101,6 +105,12 @@ task hsqlStop {
             arg(value: '--sql')
             arg(value: 'shutdown compact;')
             arg(value: 'uPortalDb')
+        }
+
+        ant.waitfor() {
+            not() {
+                socket(server: 'localhost', port: 8887)
+            }
         }
     }
 }

--- a/gradle/tasks/hsql.gradle
+++ b/gradle/tasks/hsql.gradle
@@ -1,3 +1,5 @@
+import org.gradle.api.Project
+
 repositories {
     mavenLocal()
     mavenCentral()
@@ -12,12 +14,29 @@ dependencies {
     hsqldb "org.hsqldb:sqltool:${hsqldbVersion}"  // Needed for stopping the embedded HSQLDB
 }
 
+/*
+ * Used by tasks in this file to avoid trying to start the HSQL service twice, etc.
+ */
+private boolean verifyHsqlState(Project project, boolean verifyRunning) {
+    project.ant {
+        condition(property: 'hsqlIsRunning', value: true, else: false) {
+            socket(server: 'localhost', port: 8887)
+        }
+        if (Boolean.valueOf(hsqlIsRunning) != verifyRunning) {
+            logger.lifecycle("The embedded HSQLDB uPortal database ${verifyRunning ? 'is not currently' : 'is already'} running; nothing to do")
+            throw new StopExecutionException()
+        }
+    }
+}
+
 task hsqlStart {
     group 'HSQL'
     description 'Start the embedded hsql server'
     dependsOn project.tasks.portalProperties
 
     doLast {
+        verifyHsqlState(project, false)
+
         logger.lifecycle('Starting embedded HSQLDB uPortal database')
 
         String classpathSeparatorCharacter = isWindows ? ';' : ':'
@@ -49,42 +68,14 @@ task hsqlStart {
     }
 }
 
-
-task hsqlOpen {
-    group 'HSQL'
-    description 'Launch the HSQL Database Manager connected to the default HSQL database'
-    dependsOn project.tasks.portalProperties
-
-    doLast {
-        logger.lifecycle('Starting the HSQLDB Database Manager, connected to the default HSQL database [uPortal]')
-
-        String classpathSeparatorCharacter = isWindows ? ';' : ':'
-        String classpath = '';
-        configurations.hsqldb.resolve().each {
-            if (classpath.length() != 0) {
-                classpath += classpathSeparatorCharacter
-            }
-            classpath += it.getAbsolutePath()
-        }
-
-        ant.exec(executable: 'java', spawn: true) {
-            arg(value: '-cp')
-            arg(value: classpath)
-            arg(value: 'org.hsqldb.util.DatabaseManagerSwing')
-            arg(value: '--url')
-            arg(value: 'jdbc:hsqldb:hsql://localhost:8887/uPortal')
-            arg(value: '--user')
-            arg(value: 'SA')
-        }
-    }
-}
-
 task hsqlStop {
     group 'HSQL'
     description 'Stop the embedded hsql server'
     dependsOn project.tasks.portalProperties
 
     doLast {
+        verifyHsqlState(project, true)
+
         logger.lifecycle('Stopping embedded HSQLDB uPortal database')
 
         String classpathSeparatorCharacter = isWindows ? ';' : ':'
@@ -111,6 +102,36 @@ task hsqlStop {
             not() {
                 socket(server: 'localhost', port: 8887)
             }
+        }
+    }
+}
+
+task hsqlOpen {
+    group 'HSQL'
+    description 'Launch the HSQL Database Manager connected to the default HSQL database'
+    dependsOn project.tasks.portalProperties
+    dependsOn hsqlStart
+
+    doLast {
+        logger.lifecycle('Starting the HSQLDB Database Manager, connected to the default HSQL database [uPortal]')
+
+        String classpathSeparatorCharacter = isWindows ? ';' : ':'
+        String classpath = '';
+        configurations.hsqldb.resolve().each {
+            if (classpath.length() != 0) {
+                classpath += classpathSeparatorCharacter
+            }
+            classpath += it.getAbsolutePath()
+        }
+
+        ant.exec(executable: 'java', spawn: true) {
+            arg(value: '-cp')
+            arg(value: classpath)
+            arg(value: 'org.hsqldb.util.DatabaseManagerSwing')
+            arg(value: '--url')
+            arg(value: 'jdbc:hsqldb:hsql://localhost:8887/uPortal')
+            arg(value: '--user')
+            arg(value: 'SA')
         }
     }
 }

--- a/gradle/tasks/portal.gradle
+++ b/gradle/tasks/portal.gradle
@@ -14,6 +14,7 @@ task portalOpen() {
     group 'Portal'
     description 'Opens the Default URL in a browser'
     dependsOn project.tasks.portalProperties
+    dependsOn project.tasks.tomcatStart
 
     doLast {
         java.awt.Desktop.desktop.browse 'http://localhost:8080/uPortal/'.toURI()

--- a/gradle/tasks/tomcat.gradle
+++ b/gradle/tasks/tomcat.gradle
@@ -1,3 +1,5 @@
+apply plugin: 'announce'
+
 repositories {
     mavenLocal()
     mavenCentral()
@@ -96,6 +98,12 @@ task tomcatStart() {
                 arg(value: 'startup.bat')
             }
         }
+
+        ant.waitfor() {
+            http(url: 'http://localhost:8080/uPortal', followRedirects: false)
+        }
+
+        announce.announce('tomcat has start', 'local')
     }
 }
 
@@ -112,6 +120,11 @@ task tomcatStop() {
             if (isWindows) {
                 arg(value: '/c')
                 arg(value: 'shutdown.bat')
+            }
+        }
+        ant.waitfor() {
+            not() {
+                http(url: 'http://localhost:8080/uPortal', followRedirects: false)
             }
         }
     }

--- a/gradle/tasks/tomcat.gradle
+++ b/gradle/tasks/tomcat.gradle
@@ -19,6 +19,21 @@ dependencies {
     shared "${portletApiDependency}"
 }
 
+/*
+ * Used by tasks in this file to avoid trying to start the Tomcat service twice, etc.
+ */
+private boolean verifyTomcatState(Project project, boolean verifyRunning) {
+    project.ant {
+        condition(property: 'tomcatIsRunning', value: true, else: false) {
+            socket(server: 'localhost', port: 8080)
+        }
+        if (Boolean.valueOf(tomcatIsRunning) != verifyRunning) {
+            logger.lifecycle("The embedded Tomcat servlet container ${verifyRunning ? 'is not currently' : 'is already'} running; nothing to do")
+            throw new StopExecutionException()
+        }
+    }
+}
+
 task tomcatInstall() {
     group 'Tomcat'
     description 'Downloads the Apache Tomcat servlet container and performs the necessary configuration steps'
@@ -87,6 +102,8 @@ task tomcatStart() {
     dependsOn project.tasks.portalProperties
 
     doLast {
+        verifyTomcatState(project, false)
+
         String serverHome = rootProject.ext['buildProperties'].getProperty('server.home')
         logger.lifecycle("Starting Tomcat servlet container in ${serverHome}")
         String executable = isWindows ? 'cmd' : './startup.sh'
@@ -111,6 +128,8 @@ task tomcatStop() {
     dependsOn project.tasks.portalProperties
 
     doLast {
+        verifyTomcatState(project, true)
+
         String serverHome = rootProject.ext['buildProperties'].getProperty('server.home')
         logger.lifecycle("Stopping Tomcat servlet container in ${serverHome}")
         String executable = isWindows ? 'cmd' : './shutdown.sh'

--- a/gradle/tasks/tomcat.gradle
+++ b/gradle/tasks/tomcat.gradle
@@ -1,5 +1,3 @@
-apply plugin: 'announce'
-
 repositories {
     mavenLocal()
     mavenCentral()
@@ -103,7 +101,7 @@ task tomcatStart() {
             http(url: 'http://localhost:8080/uPortal', followRedirects: false)
         }
 
-        announce.announce('tomcat has start', 'local')
+        logger.lifecycle('Tomcat has finished loading webapps, local uPortal server is live')
     }
 }
 


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.

Bug fixes and new features should be reported on the issue tracker: https://issues.jasig.org/browse/UP/

Contributors guide: https://github.com/Jasig/uPortal/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

-   [x] the [individual contributor license agreement][] is signed
-   [x] commit message follows [commit guidelines][]


##### Description of change
<!-- Provide a description of the change below this comment. -->

![tomcat-has-started](https://user-images.githubusercontent.com/3107513/35199823-ef6371e2-fec0-11e7-9742-42a959a6eef6.gif)

<!-- Reference Links -->

[individual contributor license agreement]: https://github.com/Jasig/uPortal/blob/master/CONTRIBUTING.md#individual-contributor-license-agreement
[commit guidelines]: https://github.com/Jasig/uPortal/blob/master/CONTRIBUTING.md#commit
[message properties]: https://github.com/Jasig/uPortal/tree/master/uportal-war/src/main/resources/properties/i18n
[WCAG 2.0 AA]: https://www.w3.org/WAI/WCAG20/quickref/?levels=aaa&technologies=smil%2Cpdf%2Cflash%2Csl
