### PR TITLE
WPT-87:  Upgraded WeatherPortlet to 1.1.6

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -17,7 +17,7 @@ notificationPortletVersion=3.2.0
 sakaiConnectorPortletVersion=1.5.2
 simpleContentPortletVersion=2.2.0
 uPortalVersion=5.0.4
-weatherPortletVersion=1.1.5
+weatherPortletVersion=1.1.6
 webProxyPortletVersion=2.3.1
 
 portletApiDependency=org.apache.portals:portlet-api_2.1.0_spec:1.0


### PR DESCRIPTION
##### Checklist
-   [x] the [individual contributor license agreement][] is signed
-   [x] commit message follows [commit guidelines][]

##### Description of change
Upgrade WeatherPortlet to 1.1.6 to resolve the broken city links for Yahoo.  Reference to https://issues.jasig.org/browse/WPT-87

<!-- Reference Links -->

[individual contributor license agreement]: https://github.com/Jasig/uPortal/blob/master/CONTRIBUTING.md#individual-contributor-license-agreement
[commit guidelines]: https://github.com/Jasig/uPortal/blob/master/CONTRIBUTING.md#commit
[message properties]: https://github.com/Jasig/uPortal/tree/master/uportal-war/src/main/resources/properties/i18n
[WCAG 2.0 AA]: https://www.w3.org/WAI/WCAG20/quickref/?levels=aaa&technologies=smil%2Cpdf%2Cflash%2Csl
