### PR TITLE
feat(build): add gradle tomcat start with jpda property

### DIFF
--- a/gradle/tasks/tomcat.gradle
+++ b/gradle/tasks/tomcat.gradle
@@ -122,6 +122,34 @@ task tomcatStart() {
     }
 }
 
+task tomcatStartWithDebugger() {
+    group 'Tomcat'
+    description 'Start the embedded Tomcat servlet container with remote debugging'
+    dependsOn project.tasks.portalProperties
+
+    doLast {
+        verifyTomcatState(project, false)
+
+        String serverHome = rootProject.ext['buildProperties'].getProperty('server.home')
+        logger.lifecycle("Starting Tomcat servlet container in ${serverHome}")
+        String executable = isWindows ? 'cmd' : './catalina.sh'
+        ant.exec(dir: "${serverHome}/bin", executable: executable, spawn: true) {
+            if (isWindows) {
+                arg(value: '/c')
+                arg(value: 'catalina.bat')
+            }
+            arg(value: 'jpda')
+            arg(value: 'start')
+        }
+
+        ant.waitfor() {
+            http(url: 'http://localhost:8080/uPortal', followRedirects: false)
+        }
+
+        logger.lifecycle('Tomcat has finished loading webapps, local uPortal server is live')
+    }
+}
+
 task tomcatStop() {
     group 'Tomcat'
     description 'Stop the embedded Tomcat servlet container'

--- a/gradle/tasks/tomcat.gradle
+++ b/gradle/tasks/tomcat.gradle
@@ -112,7 +112,7 @@ task tomcatStart() {
                 arg(value: '/c')
                 arg(value: 'catalina.bat')
             }
-            if (project.hasProperty('with-jdba')) {
+            if (project.hasProperty('with-jpda')) {
                 arg(value: 'jpda')
             }
             arg(value: 'start')

--- a/gradle/tasks/tomcat.gradle
+++ b/gradle/tasks/tomcat.gradle
@@ -106,39 +106,15 @@ task tomcatStart() {
 
         String serverHome = rootProject.ext['buildProperties'].getProperty('server.home')
         logger.lifecycle("Starting Tomcat servlet container in ${serverHome}")
-        String executable = isWindows ? 'cmd' : './startup.sh'
-        ant.exec(dir: "${serverHome}/bin", executable: executable, spawn: true) {
-            if (isWindows) {
-                arg(value: '/c')
-                arg(value: 'startup.bat')
-            }
-        }
-
-        ant.waitfor() {
-            http(url: 'http://localhost:8080/uPortal', followRedirects: false)
-        }
-
-        logger.lifecycle('Tomcat has finished loading webapps, local uPortal server is live')
-    }
-}
-
-task tomcatStartWithDebugger() {
-    group 'Tomcat'
-    description 'Start the embedded Tomcat servlet container with remote debugging'
-    dependsOn project.tasks.portalProperties
-
-    doLast {
-        verifyTomcatState(project, false)
-
-        String serverHome = rootProject.ext['buildProperties'].getProperty('server.home')
-        logger.lifecycle("Starting Tomcat servlet container in ${serverHome}")
         String executable = isWindows ? 'cmd' : './catalina.sh'
         ant.exec(dir: "${serverHome}/bin", executable: executable, spawn: true) {
             if (isWindows) {
                 arg(value: '/c')
                 arg(value: 'catalina.bat')
             }
-            arg(value: 'jpda')
+            if (project.hasProperty('with-jdba')) {
+                arg(value: 'jpda')
+            }
             arg(value: 'start')
         }
 


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.

Bug fixes and new features should be reported on the issue tracker: https://issues.jasig.org/browse/UP/

Contributors guide: https://github.com/Jasig/uPortal/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

-   [x] the [individual contributor license agreement][] is signed
-   [x] commit message follows [commit guidelines][]

##### Description of change
<!-- Provide a description of the change below this comment. -->

This gives a quick way to start Tomcat with JPDA remote debugging enabled on port 8000.

<!-- Reference Links -->

[individual contributor license agreement]: https://github.com/Jasig/uPortal/blob/master/CONTRIBUTING.md#individual-contributor-license-agreement
[commit guidelines]: https://github.com/Jasig/uPortal/blob/master/CONTRIBUTING.md#commit
[message properties]: https://github.com/Jasig/uPortal/tree/master/uportal-war/src/main/resources/properties/i18n
[WCAG 2.0 AA]: https://www.w3.org/WAI/WCAG20/quickref/?levels=aaa&technologies=smil%2Cpdf%2Cflash%2Csl
