### PR TITLE
Enhance the tasks in tomcat.gradle by adding logical 'mustRunAfter' r…

### DIFF
--- a/gradle/tasks/portal.gradle
+++ b/gradle/tasks/portal.gradle
@@ -17,6 +17,8 @@ task portalOpen() {
     dependsOn project.tasks.tomcatStart
 
     doLast {
-        java.awt.Desktop.desktop.browse 'http://localhost:8080/uPortal/'.toURI()
+        String portalUrl = 'http://localhost:8080/uPortal/' // Can we calculate?
+        logger.lifecycle("Opening uPortal in the default browser at ${portalUrl}")
+        java.awt.Desktop.desktop.browse portalUrl.toURI()
     }
 }

--- a/gradle/tasks/tomcat.gradle
+++ b/gradle/tasks/tomcat.gradle
@@ -37,7 +37,7 @@ private boolean verifyTomcatState(Project project, boolean verifyRunning) {
 task tomcatInstall() {
     group 'Tomcat'
     description 'Downloads the Apache Tomcat servlet container and performs the necessary configuration steps'
-    dependsOn project.tasks.portalProperties
+    dependsOn ':portalProperties'
 
     doLast {
         String serverHome = rootProject.ext['buildProperties'].getProperty('server.home')
@@ -99,7 +99,18 @@ task tomcatInstall() {
 task tomcatStart() {
     group 'Tomcat'
     description 'Start the embedded Tomcat servlet container'
-    dependsOn project.tasks.portalProperties
+    dependsOn ':portalProperties'
+
+    /*
+     * When chain tasks together -- which is often convenient -- there are some other tasks that
+     * may potentially be included in the Task Graph that really need to complete before we start
+     * this one.
+     */
+    mustRunAfter ':tomcatInstall'
+    mustRunAfter allprojects.collect { it.tasks.matching { it.name.equals('tomcatDeploy') } }
+    mustRunAfter ':deployPortletApp'
+    mustRunAfter ':hsqlStart'
+    mustRunAfter allprojects.collect { it.tasks.matching { it.name.equals('dataInit') } }
 
     doLast {
         verifyTomcatState(project, false)
@@ -125,7 +136,7 @@ task tomcatStart() {
 task tomcatStop() {
     group 'Tomcat'
     description 'Stop the embedded Tomcat servlet container'
-    dependsOn project.tasks.portalProperties
+    dependsOn ':portalProperties'
 
     doLast {
         verifyTomcatState(project, true)
@@ -150,7 +161,7 @@ task tomcatStop() {
 task tomcatClearLogs(type: Delete) {
     group 'Tomcat'
     description 'Delete all log files within Tomcat'
-    dependsOn project.tasks.portalProperties
+    dependsOn ':portalProperties'
 
     doFirst {
         String serverBase = rootProject.ext['buildProperties'].getProperty('server.base')
@@ -169,8 +180,8 @@ task tomcatClearLogs(type: Delete) {
 task tomcatZip {
     group 'Tomcat'
     description 'Create a zip file of Tomcat (base) with uPortal and portlets'
-    dependsOn tomcatInstall
-    dependsOn allprojects.collect { it.tasks.matching { it.name.equals('tomcatDeploy') } }
+    mustRunAfter tomcatInstall
+    mustRunAfter allprojects.collect { it.tasks.matching { it.name.equals('tomcatDeploy') } }
 
     doLast {
         String serverBase = rootProject.ext.buildProperties.getProperty('server.base')
@@ -187,8 +198,8 @@ task tomcatZip {
 task tomcatTar {
     group 'Tomcat'
     description 'Create a .tar.gz file of Tomcat (base) with uPortal and portlets'
-    dependsOn tomcatInstall
-    dependsOn allprojects.collect { it.tasks.matching { it.name.equals('tomcatDeploy') } }
+    mustRunAfter tomcatInstall
+    mustRunAfter allprojects.collect { it.tasks.matching { it.name.equals('tomcatDeploy') } }
 
     doLast {
         String serverBase = rootProject.ext.buildProperties.getProperty('server.base')

--- a/gradle/tasks/tomcat.gradle
+++ b/gradle/tasks/tomcat.gradle
@@ -102,7 +102,7 @@ task tomcatStart() {
     dependsOn ':portalProperties'
 
     /*
-     * When chain tasks together -- which is often convenient -- there are some other tasks that
+     * When we chain tasks together -- which is often convenient -- there are some other tasks that
      * may potentially be included in the Task Graph that really need to complete before we start
      * this one.
      */
@@ -180,7 +180,7 @@ task tomcatClearLogs(type: Delete) {
 task tomcatZip {
     group 'Tomcat'
     description 'Create a zip file of Tomcat (base) with uPortal and portlets'
-    mustRunAfter tomcatInstall
+    mustRunAfter ':tomcatInstall'
     mustRunAfter allprojects.collect { it.tasks.matching { it.name.equals('tomcatDeploy') } }
 
     doLast {
@@ -198,7 +198,7 @@ task tomcatZip {
 task tomcatTar {
     group 'Tomcat'
     description 'Create a .tar.gz file of Tomcat (base) with uPortal and portlets'
-    mustRunAfter tomcatInstall
+    mustRunAfter ':tomcatInstall'
     mustRunAfter allprojects.collect { it.tasks.matching { it.name.equals('tomcatDeploy') } }
 
     doLast {


### PR DESCRIPTION
…elationships for tasks that could potentially be in the Task Graph

<!--
Thank you for your pull request. Please review below requirements.

Bug fixes and new features should be reported on the issue tracker: https://issues.jasig.org/browse/UP/

Contributors guide: https://github.com/Jasig/uPortal/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

-   [x] the [individual contributor license agreement][] is signed
-   [x] commit message follows [commit guidelines][]

##### Description of change
<!-- Provide a description of the change below this comment. -->

In `uPortal-start`, it is often convenient to chain 2 or more Gradle tasks together, _e.g._...

```
$ ./gradlew tomcatClearLogs tomcatStart
```

But when `tomcatStart` is in the chain, there's a pretty good likelihood that there will be other tasks in the Gradle Task Graph (_e.g._ `tomcatDeploy` or `dataInit`) that really need to complete before `tomcatStart` even begins.

This change adds `mustRunAfter` relationships to (primarily) `tomcatStart` so that chaining Gradle tasks together will work as intended.

<!-- Reference Links -->

[individual contributor license agreement]: https://github.com/Jasig/uPortal/blob/master/CONTRIBUTING.md#individual-contributor-license-agreement
[commit guidelines]: https://github.com/Jasig/uPortal/blob/master/CONTRIBUTING.md#commit
[message properties]: https://github.com/Jasig/uPortal/tree/master/uportal-war/src/main/resources/properties/i18n
[WCAG 2.0 AA]: https://www.w3.org/WAI/WCAG20/quickref/?levels=aaa&technologies=smil%2Cpdf%2Cflash%2Csl
