### PR TITLE
Updated Announcements' log4j.properties

### DIFF
--- a/overlays/Announcements/src/main/resources/log4j.properties
+++ b/overlays/Announcements/src/main/resources/log4j.properties
@@ -29,11 +29,14 @@
 #
 log4j.rootCategory=INFO, R
 
+#Silence an erroneous WARN level log message from Hibernate
+log4j.logger.org.hibernate.engine.loading.LoadContexts=ERROR, R
+log4j.additivity.org.hibernate.engine.loading.LoadContexts=false
 
 ###########################################################################
 # Setup a rolling file appender
 #
-log4j.appender.R=org.apache.log4j.DailyRollingFileAppender
+log4j.appender.R=org.apache.log4j.RollingFileAppender
 
 ###########################################################################
 # Uncomment the next line to have messages go to stdout (System.out)
@@ -53,17 +56,26 @@ log4j.appender.R.File=${catalina.base}/logs/AnnouncementsPortlet.log
 #
 log4j.appender.R.Encoding=UTF-8
 
+# This is the maximum size that the portal log file will grow before being rolled
+#
+log4j.appender.R.MaxFileSize=3000KB
+
+# This is the maximum number of rolled log files that will be maintained
+#
+log4j.appender.R.MaxBackupIndex=10
+
 # This tells log4j to use PatternLayout for log file formatting
 #
 log4j.appender.R.layout=org.apache.log4j.PatternLayout
 
 # Pattern used during debugging
 #
-#log4j.appender.R.layout.ConversionPattern=%5p [%t] %d{MMM/dd HH:mm:ss,SSS} %c{2}.[%x] (%F:%L) - %m%n
+#log4j.appender.R.layout.ConversionPattern=%5p [%t] %c{2}.[%x] (%F:%L) %d{MMM/dd HH:mm:ss} - %m%n
 
 # Pattern that should be used when speed is important (it doesn't provide location info)
 #
-log4j.appender.R.layout.ConversionPattern=%5p [%t] %c{2}.[%x] %d{ISO8601} - %m%n
+log4j.appender.R.layout.ConversionPattern=%5p [%t] %c{2}.[%x] %d{MMM/dd HH:mm:ss} - %m%n
 
-# Log file rolling frequency. Default is '.'yyyy-MM-dd
-log4j.appender.R.DatePattern='.'yyyy-MM-dd
+log4j.logger.com.whirlycott.cache=WARN, R
+log4j.logger.org.apache.commons.digester=WARN, R
+log4j.logger.org.xml.sax=WARN, R


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.

Bug fixes and new features should be reported on the issue tracker: https://issues.jasig.org/browse/UP/

Contributors guide: https://github.com/Jasig/uPortal/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

-   [x] the [individual contributor license agreement][] is signed
-   [x] commit message follows [commit guidelines][]

##### Description of change
<!-- Provide a description of the change below this comment. -->
We've discovered that we were on our way to having a year's worth of Announcements Portlet logs. 

This PR updates log4j.properties with the one from the AnnouncementsPortlet repository (at the version tag indicated in gradle.properties). This change means that logs for this portlet that are older than 10 days would be deleted

I'm not sure what purpose `log4j.appender.R.MaxFileSize` serves. Maybe we can start discussing an update to the defaults ;)

<!-- Reference Links -->

[individual contributor license agreement]: https://github.com/Jasig/uPortal/blob/master/CONTRIBUTING.md#individual-contributor-license-agreement
[commit guidelines]: https://github.com/Jasig/uPortal/blob/master/CONTRIBUTING.md#commit
[message properties]: https://github.com/Jasig/uPortal/tree/master/uportal-war/src/main/resources/properties/i18n
[WCAG 2.0 AA]: https://www.w3.org/WAI/WCAG20/quickref/?levels=aaa&technologies=smil%2Cpdf%2Cflash%2Csl
