### PR TITLE
Provide MariaDB install documentation change from personal install

### DIFF
--- a/docs/database/index.md
+++ b/docs/database/index.md
@@ -57,8 +57,7 @@ environment.build.hibernate.connection.validationQuery=select 1
 
 ## Step 4: Copy `global.properties` to local environment location and add credentials and URL
 
-In uPortal 5, deployers are strongly encouraged to configure a local `portal.home` directory to keep configuration
-that is specific to the environment but should not be captured in a repo. In particular, database and other service
+In uPortal 5, deployers are strongly encouraged to configure a local `portal.home` directory to keep configuration that is specific to the environment but should not be captured in a repo. In particular, database and other service
 credentials should not be captured. If `portal.home` is not configured, the default is the portal/ directory in Tomcat.
 
 During `./gradlew portalInit` or `./gradlew tomcatInstall`, the files from the repo's `etc/portal/` directory are
@@ -74,6 +73,17 @@ environment.build.hibernate.connection.password=[actual password for this db]
 environment.build.hibernate.dialect=org.hibernate.dialect.SQLServerDialect
 environment.build.hibernate.connection.validationQuery=select 1
 ```
+
+## Step 5: Specific portlet / uPortal database configuration (optional)
+
+The default configuration come from the file `global.properties` in the `portal.home` directory to deploy all applications.
+But it's possible to define a specific configuration per application/portlet, the `global.properties` will be always used but it could be overriden by a specific property file if found.
+
+For the uPortal database you will need to add database's' properties from `global.properties` into `uPortal.properties` file.
+For each portlets you should define same properties by adding the `specific-portlet.properties` into the `portal.home` directory, where `specific-portlet.properties` is the file name defined in the portlet spring context definition sources.
+As example, for `NewsReaderPortlet` the named file will be `news-reader.properties`, the file name can be found [in the NewsReaderPortlet project here.](https://github.com/Jasig/NewsReaderPortlet/blob/master/src/main/resources/context/databaseContext.xml)
+
+Note: Also these files can be used for other properties !
 
 ## uPortal Production Database Configuration 
 

--- a/docs/database/mariadb.md
+++ b/docs/database/mariadb.md
@@ -1,10 +1,4 @@
-# MariaDB Database Configuration
-
-uPortal is configured to use a default HSQL database.
-
-**This database configuration is not suitable for production deployments but is better suited for testing purposes.**
-
-uPortal supports a number of production databases and you can configure the MariaDB database.
+# Configuration with MariaDB Database
 
 ## Step 1: MariaDB server setup
 Edit the file /etc/mysql/mariadb.conf.d/60-server.cnf. (Debian 9)
@@ -32,10 +26,11 @@ innodb_log_buffer_size=64M
 ```properties
 mysql -uroot -p
 
-MariaDB [(none)]> create database uportal CHARACTER SET utf8 COLLATE utf8_general_ci;
-MariaDB [(none)]> create database portlets CHARACTER SET utf8 COLLATE utf8_general_ci;
 CREATE USER 'uportal'@'localhost' IDENTIFIED BY 'uportal';
+create database uportal CHARACTER SET utf8 COLLATE utf8_general_ci;
 GRANT ALL PRIVILEGES ON uportal.* TO 'portail'@'localhost';
+# If you want to install portlets on an other database
+create database portlets CHARACTER SET utf8 COLLATE utf8_general_ci;
 GRANT ALL PRIVILEGES ON portlets.* TO 'portail'@'localhost';
 ```
 ## Step 3: Configure Uportal 
@@ -50,16 +45,10 @@ dependencies {
         /*
          * Add additional JDBC driver jars to the 'jdbc' configuration below;
          * do not remove the hsqldb driver jar that is already listed.
-         *
+         */
         jdbc "org.hsqldb:hsqldb:${hsqldbVersion}"
-        */
         jdbc "mysql:mysql-connector-java:${mysqldbVersion}"
         
-        /*
-         * These are nearly the same uPortal dependencies declared by uPortal-webapp;
-         * perhaps we should create a uPortal-all module to bundle them all as transitives.
-         */
-
 ```
 
 ### Edit uPortal-start/etc/portal/global.properties 
@@ -71,9 +60,10 @@ hibernate.connection.url=jdbc:mysql://localhost/portlets
 hibernate.connection.username=uportal
 hibernate.connection.password=uportal
 hibernate.connection.validationQuery=select 1
-hibernate.dialect = org.hibernate.dialect.MySQL5InnoDBDialect
+hibernate.dialect = org.apereo.portal.utils.MySQL5InnoDBCompressedDialect
 ```
 ### Edit uPortal-start/etc/portal/uPortal.properties
+**this step is needed only if you install portlets on a different database**
 
 ```properties
 hibernate.connection.driver_class=com.mysql.jdbc.Driver
@@ -81,7 +71,7 @@ hibernate.connection.url=jdbc:mysql://localhost/uportal
 hibernate.connection.username=uportal
 hibernate.connection.password=uportal
 hibernate.connection.validationQuery=select 1
-hibernate.dialect = org.hibernate.dialect.MySQL5InnoDBDialect
+hibernate.dialect = org.apereo.portal.utils.MySQL5InnoDBCompressedDialect
 ```
 
 ## Step 4 : Initialization of the Database

--- a/docs/database/mariadb.md
+++ b/docs/database/mariadb.md
@@ -23,15 +23,15 @@ innodb_log_buffer_size=64M
 ```
 
 ## Step 2: Configure the user and database
-```properties
-mysql -uroot -p
 
+Connect to the database server.
+```SQL
 CREATE USER 'uportal'@'localhost' IDENTIFIED BY 'uportal';
 create database uportal CHARACTER SET utf8 COLLATE utf8_general_ci;
 GRANT ALL PRIVILEGES ON uportal.* TO 'portail'@'localhost';
-# If you want to install portlets on an other database
-create database portlets CHARACTER SET utf8 COLLATE utf8_general_ci;
-GRANT ALL PRIVILEGES ON portlets.* TO 'portail'@'localhost';
+# If you want to install portlets on a specific database
+#create database portlets CHARACTER SET utf8 COLLATE utf8_general_ci;
+#GRANT ALL PRIVILEGES ON portlets.* TO 'portail'@'localhost';
 ```
 ## Step 3: Configure Uportal 
 
@@ -62,17 +62,7 @@ hibernate.connection.password=uportal
 hibernate.connection.validationQuery=select 1
 hibernate.dialect = org.apereo.portal.utils.MySQL5InnoDBCompressedDialect
 ```
-### Edit uPortal-start/etc/portal/uPortal.properties
-**this step is needed only if you install portlets on a different database**
-
-```properties
-hibernate.connection.driver_class=com.mysql.jdbc.Driver
-hibernate.connection.url=jdbc:mysql://localhost/uportal
-hibernate.connection.username=uportal
-hibernate.connection.password=uportal
-hibernate.connection.validationQuery=select 1
-hibernate.dialect = org.apereo.portal.utils.MySQL5InnoDBCompressedDialect
-```
+You should copy/paste this configuration for each customized database portlet/uPortal context [see global datasource documentation](index.md#step-5-specific-portlet-uportal-database-configuration-optional)
 
 ## Step 4 : Initialization of the Database
 ```shell

--- a/docs/database/mysql.md
+++ b/docs/database/mysql.md
@@ -1,0 +1,1 @@
+Until Mysql and MariaDB have the same server configuration you can watch on [MariaDB](mariadb.md) configuration !

--- a/docs/fr/database/index.md
+++ b/docs/fr/database/index.md
@@ -75,6 +75,17 @@ environment.build.hibernate.dialect=org.hibernate.dialect.SQLServerDialect
 environment.build.hibernate.connection.validationQuery=select 1
 ```
 
+## Étape 5: Configuration spécifique portlet / uPortal (optionel)
+
+La configuration utilisée par défaut pour déployer toutes les applications vient du fichier `global.properties` dans le répertoire `portal.home`.
+Mais il est tout à fait possible de définir une configuration par application/portlet, le fichier `global.properties` sera toujours utilisé mais il peut être surchargé par un fichier spécifique s'il est trouvé.
+
+Pour la base de données uPortal il sera nécessaire de recopier les mêmes propriétés de base de données du fichier `global.properties` dans le fichier `uPortal.properties`.
+Pour chaque portlet il faudra aussi redéfinir les mêmes propriétés en les ajoutant dans un fichier `specific-portlet.properties` du répertoire `portal.home`, où `specific-portlet.properties` est le nom du fichier défini dans les source de configurations de contexte spring du portlet.
+Par exemple, pour `NewsReaderPortlet` le fichier sera `news-reader.properties`, le nom du fichier à définir se trouvera [dans le projet NewsReaderPortlet ici.](https://github.com/Jasig/NewsReaderPortlet/blob/master/src/main/resources/context/databaseContext.xml)
+
+Remarque: Aussi ces fichiers peuvent être utilisés pour définir d'autres propriétés !
+
 ## Configuration de la base de données de production uPortal
 
 Sélectionner la base de données ci-dessous pour des notes et des exemples de configuration.

--- a/docs/fr/database/mariadb.md
+++ b/docs/fr/database/mariadb.md
@@ -1,10 +1,4 @@
-# Configuration de la Base de Données MariaDB
-
-uPortal est configuré pour utiliser une base de données HSQL par défaut.
-
-**Cette configuration de base de données ne convient pas aux déploiements de production mais est mieux adaptée à des fins de test.**
-
-uPortal prend en charge un certain nombre de bases de données de production et vous pouvez configurer la base de données MariaDB.
+# Configuration avec une Base de Données MariaDB
 
 ## Étape 1 : Paramétrage du server MariaDB
 Editer le fichier /etc/mysql/mariadb.conf.d/60-server.cnf. (ici pour Debian 9)
@@ -32,10 +26,11 @@ innodb_log_buffer_size=64M
 ```properties
 mysql -uroot -p
 
-MariaDB [(none)]> create database uportal CHARACTER SET utf8 COLLATE utf8_general_ci;
-MariaDB [(none)]> create database portlets CHARACTER SET utf8 COLLATE utf8_general_ci;
 CREATE USER 'uportal'@'localhost' IDENTIFIED BY 'uportal';
+create database uportal CHARACTER SET utf8 COLLATE utf8_general_ci;
 GRANT ALL PRIVILEGES ON uportal.* TO 'portail'@'localhost';
+# Si vous souhaitez installer les portlets sur une autre base de données spécifique.
+create database portlets CHARACTER SET utf8 COLLATE utf8_general_ci;
 GRANT ALL PRIVILEGES ON portlets.* TO 'portail'@'localhost';
 ```
 ## Étape 3 : Configurer Uportal 
@@ -50,15 +45,9 @@ dependencies {
         /*
          * Add additional JDBC driver jars to the 'jdbc' configuration below;
          * do not remove the hsqldb driver jar that is already listed.
-         *
-        jdbc "org.hsqldb:hsqldb:${hsqldbVersion}"
-        */
-        jdbc "mysql:mysql-connector-java:${mysqldbVersion}"
-        
-        /*
-         * These are nearly the same uPortal dependencies declared by uPortal-webapp;
-         * perhaps we should create a uPortal-all module to bundle them all as transitives.
          */
+        jdbc "org.hsqldb:hsqldb:${hsqldbVersion}"
+        jdbc "mysql:mysql-connector-java:${mysqldbVersion}"
 
 ```
 
@@ -71,9 +60,10 @@ hibernate.connection.url=jdbc:mysql://localhost/portlets
 hibernate.connection.username=uportal
 hibernate.connection.password=uportal
 hibernate.connection.validationQuery=select 1
-hibernate.dialect = org.hibernate.dialect.MySQL5InnoDBDialect
+hibernate.dialect = org.apereo.portal.utils.MySQL5InnoDBCompressedDialect
 ```
 ### Éditer uPortal-start/etc/portal/uPortal.properties
+**Cette étape est nécessaire uniquement si vous souhaitez dissocier l'installation des portlets sur une autre base de données.'**
 
 ```properties
 hibernate.connection.driver_class=com.mysql.jdbc.Driver
@@ -81,7 +71,7 @@ hibernate.connection.url=jdbc:mysql://localhost/uportal
 hibernate.connection.username=uportal
 hibernate.connection.password=uportal
 hibernate.connection.validationQuery=select 1
-hibernate.dialect = org.hibernate.dialect.MySQL5InnoDBDialect
+hibernate.dialect = org.apereo.portal.utils.MySQL5InnoDBCompressedDialect
 ```
 
 ## Étape 4 : Initialisation de la Base de Donnée

--- a/docs/fr/database/mariadb.md
+++ b/docs/fr/database/mariadb.md
@@ -23,15 +23,15 @@ innodb_log_buffer_size=64M
 ```
 
 ## Étape 2 : Configurer l'utilisateur et la base de donnée
-```properties
-mysql -uroot -p
 
+Se connecter au serveur de base de données.
+```SQL
 CREATE USER 'uportal'@'localhost' IDENTIFIED BY 'uportal';
 create database uportal CHARACTER SET utf8 COLLATE utf8_general_ci;
 GRANT ALL PRIVILEGES ON uportal.* TO 'portail'@'localhost';
-# Si vous souhaitez installer les portlets sur une autre base de données spécifique.
-create database portlets CHARACTER SET utf8 COLLATE utf8_general_ci;
-GRANT ALL PRIVILEGES ON portlets.* TO 'portail'@'localhost';
+# Si vous souhaitez installer les portlets sur une base de données spécifique.
+# create database portlet CHARACTER SET utf8 COLLATE utf8_general_ci;
+# GRANT ALL PRIVILEGES ON portlet.* TO 'portail'@'localhost';
 ```
 ## Étape 3 : Configurer Uportal 
 
@@ -62,17 +62,8 @@ hibernate.connection.password=uportal
 hibernate.connection.validationQuery=select 1
 hibernate.dialect = org.apereo.portal.utils.MySQL5InnoDBCompressedDialect
 ```
-### Éditer uPortal-start/etc/portal/uPortal.properties
-**Cette étape est nécessaire uniquement si vous souhaitez dissocier l'installation des portlets sur une autre base de données.'**
 
-```properties
-hibernate.connection.driver_class=com.mysql.jdbc.Driver
-hibernate.connection.url=jdbc:mysql://localhost/uportal
-hibernate.connection.username=uportal
-hibernate.connection.password=uportal
-hibernate.connection.validationQuery=select 1
-hibernate.dialect = org.apereo.portal.utils.MySQL5InnoDBCompressedDialect
-```
+Vous devez copier/coller cette configuration pour chaque personnalisation d'accès à la base de données des contextes portlets / uPortal [cf configuration générale des bases de données](index.md#step-5-specific-portlet-uportal-database-configuration-optional)
 
 ## Étape 4 : Initialisation de la Base de Donnée
 ```shell

--- a/docs/fr/database/mysql.md
+++ b/docs/fr/database/mysql.md
@@ -1,1 +1,1 @@
-﻿
+﻿Tant que Mysql et MariaDB ont des configurations serveur similaires vous pouvez utiliser la configuration de [MariaDB](mariadb.md) !

--- a/overlays/build.gradle
+++ b/overlays/build.gradle
@@ -46,6 +46,13 @@ subprojects {
         jdbc "org.hsqldb:hsqldb:${hsqldbVersion}"
 
         /*
+         * This dependency is needed for mysql/mariadb to be able to use the dialect org.apereo.portal.utils.MySQL5InnoDBCompressedDialect
+         */
+        compile("org.jasig.portal:uPortal-utils-core:${uPortalVersion}") {
+            transitive = false
+        }
+
+        /*
          * These are nearly the same uPortal dependencies declared by uPortal-webapp;
          * perhaps we should create a uPortal-all module to bundle them all as transitives.
          */


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.

Bug fixes and new features should be reported on the issue tracker: https://issues.jasig.org/browse/UP/

Contributors guide: https://github.com/Jasig/uPortal/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

-   [x] the [individual contributor license agreement][] is signed
-   [ ] commit message follows [commit guidelines][]
-   [ ] tests are included
-   [x] documentation is changed or added

##### Description of change
<!-- Provide a description of the change below this comment. -->

To avoid problems with column length at dataabse creation on Mysql/MariaDB we need to use a custom Dialect on database creation schema as hibernate doesn't purpose it in the used version. This change purpose to include the dependency where to find the custom dialect ( https://github.com/Jasig/uPortal/blob/master/uPortal-utils/uPortal-utils-core/src/main/java/org/apereo/portal/utils/MySQL5InnoDBCompressedDialect.java) and it provides somes change on the documentation + a purposed redirect link for MySQL doc to MariaDB which have sames configuration for now !

<!-- Reference Links -->

[individual contributor license agreement]: https://github.com/Jasig/uPortal/blob/master/CONTRIBUTING.md#individual-contributor-license-agreement
[commit guidelines]: https://github.com/Jasig/uPortal/blob/master/CONTRIBUTING.md#commit
[message properties]: https://github.com/Jasig/uPortal/tree/master/uportal-war/src/main/resources/properties/i18n
[WCAG 2.0 AA]: https://www.w3.org/WAI/WCAG20/quickref/?levels=aaa&technologies=smil%2Cpdf%2Cflash%2Csl
