### PR TITLE
For MariaDB conf deployment + doc + test

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,12 +6,112 @@ matrix:
       dist: trusty
       jdk: oraclejdk8
       sudo: required
+      env: DB=mariadb
+      addons:
+        mariadb: '10.1'
     - os: linux
       dist: trusty
       jdk: openjdk8
       sudo: required
+      env: DB=mariadb
+      addons:
+        mariadb: '10.1'
+    - os: linux
+      dist: trusty
+      jdk: oraclejdk8
+      sudo: required
+      env: DB=hsql
+    - os: linux
+      dist: trusty
+      jdk: openjdk8
+      sudo: required
+      env: DB=hsql
     - os: osx
       osx_image: xcode9.1 # OSX 10.12, Oracle Java 8
+      env: DB=hsql
+
+before_script:
+  - |
+    echo Start travis
+    echo Current dir is `pwd`
+    echo Home dir is `echo ~`
+    echo TRAVIS_BUILD_DIR is $TRAVIS_BUILD_DIR
+    if [ "$DB" = 'mariadb' ]; then
+      echo mysql conf `ls -la /etc/mysql/*`
+      sudo ls -l  /etc/mysql/my.cnf
+      sudo find / -name "mariadb.cnf" -exec ls -l \{\} \;
+      sudo find / -name "my.cnf" -exec ls -l \{\} \;
+      echo "show my.cnf"
+      sudo find / -name "my.cnf" -exec sudo cat \{\} \;
+      echo "show mariadb.cnf"
+      sudo find / -name "mariadb.cnf" -exec sudo cat \{\} \;
+      sudo ls -l /var/lib/mysql/
+    fi
+
+  - |
+    echo "Setting up database"
+    #if [ "$DB" = 'mysql' ] || [ "$DB" = 'mariadb' ] || [ "$DB" = 'postgresql' ]; then
+    if [ "$DB" = 'mariadb' ]; then
+      echo "setting MariaDB"
+      echo "Default variables before custom settings"
+      mysql -e 'SHOW VARIABLES;'
+      # needed for a fast stop and to apply change
+      mysql -e 'SET GLOBAL innodb_fast_shutdown = 0;'
+      sudo service mysql stop
+      # was used in 10.1.32 : cp ./.travis/conf/database/mariadb/mariadb-server.cnf ~/.my.cnf
+      # now the configuration is read into /etc/mysql/conf.d/
+      # we override the default mariadb.cnf as nothing important is provided
+      sudo cp ./.travis/conf/database/mariadb/mariadb-server.cnf /etc/mysql/conf.d/mariadb.cnf
+      # needed to remove with 10.1.35
+      sudo rm /var/lib/mysql/ibdata1
+      sudo rm /var/lib/mysql/ib_logfile0
+      sudo rm /var/lib/mysql/ib_logfile1
+      sudo service mysql start
+
+      sudo cat /var/log/mysql/error.log
+
+      echo "creating database uportal"
+      mysql -e 'DROP DATABASE IF EXISTS uportal;'
+      mysql -e 'CREATE DATABASE IF NOT EXISTS uportal DEFAULT CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_520_ci;'
+      echo "grant privilegies for user travis on database uportal@localhost"
+      mysql -e 'GRANT ALL PRIVILEGES ON uportal.* TO travis@`127.0.0.1`;'
+      mysql -e 'SHOW CREATE DATABASE uportal;'
+
+      mysql -e 'DROP DATABASE IF EXISTS announcements;'
+      mysql -e 'CREATE DATABASE IF NOT EXISTS announcements DEFAULT CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_520_ci;'
+      echo "grant privilegies for user travis on database announcements@localhost"
+      mysql -e 'GRANT ALL PRIVILEGES ON announcements.* TO travis@`127.0.0.1`;'
+      mysql -e 'SHOW CREATE DATABASE announcements;'
+
+      mysql -e 'DROP DATABASE IF EXISTS calendar;'
+      mysql -e 'CREATE DATABASE IF NOT EXISTS calendar DEFAULT CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_520_ci;'
+      echo "grant privilegies for user travis on database calendar@localhost"
+      mysql -e 'GRANT ALL PRIVILEGES ON calendar.* TO travis@`127.0.0.1`;'
+      mysql -e 'SHOW CREATE DATABASE calendar;'
+
+      mysql -e 'DROP DATABASE IF EXISTS `news_reader`;'
+      mysql -e 'CREATE DATABASE IF NOT EXISTS `news_reader` DEFAULT CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_520_ci;'
+      echo "grant privilegies for user travis on database `news_reader`@localhost"
+      mysql -e 'GRANT ALL PRIVILEGES ON news_reader.* TO travis@`127.0.0.1`;'
+      mysql -e 'SHOW CREATE DATABASE `news_reader`;'
+
+      mysql -e 'DROP DATABASE IF EXISTS cms;'
+      mysql -e 'CREATE DATABASE IF NOT EXISTS cms DEFAULT CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_520_ci;'
+      echo "grant privilegies for user travis on database cms@localhost"
+      mysql -e 'GRANT ALL PRIVILEGES ON travis.* TO cms@`127.0.0.1`;'
+      mysql -e 'SHOW CREATE DATABASE cms;'
+
+      mysql -e 'FLUSH PRIVILEGES;'
+      mysql -e 'SHOW GRANTS;'
+      #echo "USE mysql;\nUPDATE user SET password=PASSWORD('password') WHERE user='travis';\nFLUSH PRIVILEGES;\n" | mysql -u root
+      sudo service mysql restart
+      mysql -u travis -h 127.0.0.1 -e 'SELECT VERSION(); SELECT CURRENT_USER(); show databases;'
+      mysql -e 'SHOW VARIABLES;'
+
+      echo "show error.log"
+      sudo cat /var/log/mysql/error.log
+      echo "conf MariaDB done!"
+    fi
 
 script:
   # test embedded tomcat
@@ -19,10 +119,19 @@ script:
   - ./gradlew -u -i -S tomcatStart
   - ./gradlew -u -i -S tomcatStop
   - ./gradlew -u -i -S tomcatClearLogs
-  # test HSQL
-  - ./gradlew -u -i -S hsqlStart
-  - ./gradlew -u -i -S dataInit
-  - ./gradlew -u -i -S hsqlStop
+  - |
+    if [ "$DB" = 'hsql' ]; then
+      echo "testing on hsql..."
+      ./gradlew -u -i -S hsqlStart
+      ./gradlew -u -i -S dataInit
+      ./gradlew -u -i -S hsqlStop
+    fi
+    if [ "$DB" = 'mariadb' ]; then
+      echo "testing on MariaDB..."
+      echo -n "mysqldbVersion=5.1.45" >> gradle.properties
+      sed -i '/jdbc "org.hsqldb:hsqldb:/a jdbc "mysql:mysql-connector-java:${mysqldbVersion}"' ./overlays/build.gradle
+      ./gradlew -u -i -S dataInit -Dportal.home=./.travis/conf/database/mariadb
+    fi
   # test skin generation tool
   - ./gradlew -u -i -S skinGenerate -DskinName=travis
 

--- a/.travis/conf/database/mariadb/announcements.properties
+++ b/.travis/conf/database/mariadb/announcements.properties
@@ -1,0 +1,2 @@
+hibernate.connection.url=jdbc:mysql://127.0.0.1:3306/announcements
+hibernate.dialect = org.apereo.portal.utils.hibernate3.dialects.MySQL5InnoDBCompressedDialect

--- a/.travis/conf/database/mariadb/calendar.properties
+++ b/.travis/conf/database/mariadb/calendar.properties
@@ -1,0 +1,2 @@
+hibernate.connection.url=jdbc:mysql://127.0.0.1:3306/calendar
+hibernate.dialect = org.apereo.portal.utils.hibernate3.dialects.MySQL5InnoDBCompressedDialect

--- a/.travis/conf/database/mariadb/global.properties
+++ b/.travis/conf/database/mariadb/global.properties
@@ -1,0 +1,66 @@
+#
+# Licensed to Apereo under one or more contributor license
+# agreements. See the NOTICE file distributed with this work
+# for additional information regarding copyright ownership.
+# Apereo licenses this file to you under the Apache License,
+# Version 2.0 (the "License"); you may not use this file
+# except in compliance with the License.  You may obtain a
+# copy of the License at the following location:
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+##
+## global.properties
+## -----------------
+##
+## In this file, you can manage all the same properties as uPortal.properties with one key
+## difference:  this file may be sourced by uPortal modules (e,g, portlets) as well as by uPortal
+## itself.  This file is an excellent place to manage configuration that is shared between uPortal
+## and one or more modules (e.g. database connection settings).
+##
+##
+## Please keep the formatting of this properties file as follows:
+##
+##   ##
+##   ## Comment line 1
+##   ## Comment line 2, etc
+##   ##                     <-- (leave a blank commented line)
+##   property_name=property_value
+##                          <-- (leave a blank line...
+##                          <--  or two blank lines before a new section)
+##
+## Leave properties that you do not wish to overrride commented-out with a single '#' and set to
+## the default value (for reference).
+##
+
+
+################################################################################
+##                                                                            ##
+##                             Database Connection                            ##
+##                                                                            ##
+################################################################################
+
+##
+## Not all modules bundled with uPortal require a database connection;  but all the ones that do use
+## the same properties to connect.  These property names are standard for Hibernate-based
+## persistence in Java projects.
+##
+## You can optionally configure any module to use different connection settings from the standard
+## ones (defined here) by adding these properties to the module-specific file in portal.home
+## (e.g. announcements.properties).
+##
+hibernate.connection.driver_class=com.mysql.jdbc.Driver
+hibernate.connection.url=jdbc:mysql://127.0.0.1:3306/travis
+hibernate.connection.username=travis
+hibernate.connection.password=
+hibernate.connection.validationQuery=select 1
+hibernate.dialect = org.hibernate.dialect.MySQL5InnoDBDialect
+#hibernate.dialect = org.apereo.portal.utils.hibernate4.dialects.MySQL5InnoDBCompressedDialect

--- a/.travis/conf/database/mariadb/mariadb-server.cnf
+++ b/.travis/conf/database/mariadb/mariadb-server.cnf
@@ -1,0 +1,145 @@
+#
+# These groups are read by MariaDB server.
+# Use it for options that only the server (but not clients) should see
+#
+# See the examples of server my.cnf files in /usr/share/mysql/
+#
+
+# this is read by the standalone daemon and embedded servers
+[server]
+
+# this is only for the mysqld standalone daemon
+[mysqld]
+
+#
+# * Fine Tuning
+#
+key_buffer_size		= 192M
+max_allowed_packet	= 16M
+thread_stack		= 192K
+thread_cache_size       = 10
+# This replaces the startup script and checks MyISAM tables if needed
+# the first time they are touched
+#myisam_recover_options  = BACKUP
+# JG - up max-connexion from default 150 (cf documentation) to 1000
+max_connections        = 1000
+
+#
+# * Query Cache Configuration
+#
+query_cache_type = ON
+# JG - up from 16M to 128M
+query_cache_size = 128M
+query_cache_limit = 10M
+
+#
+# * Logging and Replication
+#
+# Both location gets rotated by the cronjob.
+# Be aware that this log type is a performance killer.
+# As of 5.1 you can enable the log at runtime!
+#general_log_file        = /var/log/mysql/mysql.log
+#general_log             = 1
+#
+# Error log - should be very few entries.
+#
+log_error = /var/log/mysql/error.log
+#
+# Enable the slow query log to see queries with especially long duration
+#slow_query_log_file	= /var/log/mysql/mariadb-slow.log
+#long_query_time = 10
+#log_slow_rate_limit	= 1000
+#log_slow_verbosity	= query_plan
+#log-queries-not-using-indexes
+#
+# The following can be used as easy to replay backup logs or for replication.
+# note: if you are setting up a replication slave, see README.Debian about
+#       other settings you may need to change.
+#server-id		= 1
+#log_bin			= /var/log/mysql/mysql-bin.log
+expire_logs_days	= 10
+max_binlog_size   = 100M
+#binlog_do_db		= include_database_name
+#binlog_ignore_db	= exclude_database_name
+
+#
+# tables names are stored in lowercase and not compared in a case-sensitive manner
+lower_case_table_names = 1
+#
+# SQL mode : mode strict
+sql-mode="STRICT_TRANS_TABLES,ERROR_FOR_DIVISION_BY_ZERO,NO_AUTO_CREATE_USER,NO_ENGINE_SUBSTITUTION"
+max_connect_errors=100
+
+#
+# * InnoDB
+#
+# InnoDB is enabled by default with a 10MB datafile in /var/lib/mysql/.
+# Read the manual for more InnoDB related options. There are many!
+default-storage-engine=INNODB
+innodb-large-prefix=1
+innodb_file_format=Barracuda
+innodb_file_format_check=1
+innodb_file_format_max=Barracuda
+innodb_file_per_table=1
+innodb_strict_mode=ON
+
+innodb_buffer_pool_size=512M
+innodb_data_home_dir=/var/lib/mysql/
+innodb_data_file_path=ibdata1:100M:autoextend
+# deprecated
+#innodb_additional_mem_pool_size=10M
+# innodb_use_global_flush_log_at_trx_commit=1
+innodb_flush_log_at_trx_commit=1
+# since v 10.0 size is 48M
+innodb_log_file_size=128M
+# default is 5M
+innodb_log_buffer_size=64M
+
+#
+# * Security Features
+#
+# Read the manual, too, if you want chroot!
+# chroot = /var/lib/mysql/
+#
+# For generating SSL certificates you can use for example the GUI tool "tinyca".
+#
+# ssl-ca=/etc/mysql/cacert.pem
+# ssl-cert=/etc/mysql/server-cert.pem
+# ssl-key=/etc/mysql/server-key.pem
+#
+# Accept only connections using the latest and most secure TLS protocol version.
+# ..when MariaDB is compiled with OpenSSL:
+# ssl-cipher=TLSv1.2
+# ..when MariaDB is compiled with YaSSL (default in Debian):
+# ssl=on
+
+#
+# * Character sets
+#
+# MySQL/MariaDB default is Latin1, but in Debian we rather default to the full
+# utf8 4-byte character set. See also client.cnf
+#
+character-set-server  = utf8mb4
+collation-server      = utf8mb4_unicode_520_ci
+
+#
+# * Unix socket authentication plugin is built-in since 10.0.22-6
+#
+# Needed so the root database user can authenticate without a password but
+# only when running as the unix root user.
+#
+# Also available for other users if required.
+# See https://mariadb.com/kb/en/unix_socket-authentication-plugin/
+
+# this is only for embedded server
+[embedded]
+
+# This group is only read by MariaDB servers, not by MySQL.
+# If you use the same .cnf file for MySQL and MariaDB,
+# you can put MariaDB-only options here
+[mariadb]
+
+# This group is only read by MariaDB-10.1 servers.
+# If you use the same .cnf file for MariaDB of different versions,
+# use this group for options that older servers don't understand
+[mariadb-10.1]

--- a/.travis/conf/database/mariadb/news-reader.properties
+++ b/.travis/conf/database/mariadb/news-reader.properties
@@ -1,0 +1,2 @@
+hibernate.connection.url=jdbc:mysql://127.0.0.1:3306/news_reader
+hibernate.dialect = org.apereo.portal.utils.hibernate3.dialects.MySQL5InnoDBCompressedDialect

--- a/.travis/conf/database/mariadb/simple-cms.properties
+++ b/.travis/conf/database/mariadb/simple-cms.properties
@@ -1,0 +1,2 @@
+hibernate.connection.url=jdbc:mysql://127.0.0.1:3306/cms
+hibernate.dialect = org.apereo.portal.utils.hibernate4.dialects.MySQL5InnoDBCompressedDialect

--- a/.travis/conf/database/mariadb/uPortal.properties
+++ b/.travis/conf/database/mariadb/uPortal.properties
@@ -1,0 +1,151 @@
+#
+# Licensed to Apereo under one or more contributor license
+# agreements. See the NOTICE file distributed with this work
+# for additional information regarding copyright ownership.
+# Apereo licenses this file to you under the Apache License,
+# Version 2.0 (the "License"); you may not use this file
+# except in compliance with the License.  You may obtain a
+# copy of the License at the following location:
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+##
+## uPortal.properties
+## ------------------
+##
+## Use this file to override the default values of configuration settings.  All settings in the
+## portal have a default value baked-into the build.  These defaults are suitable for a local
+## development environment.  Place a copy of this file in your ${portal.home} directory and edit to
+## taste.  The default value of ${portal.home} is '${catalina.base}/portal', but you can choose
+## your own location by setting a PORTAL_HOME environment variable.
+##
+## Please keep the formatting of this properties file as follows:
+##
+##   ##
+##   ## Comment line 1
+##   ## Comment line 2, etc
+##   ##                     <-- (leave a blank commented line)
+##   property_name=property_value
+##                          <-- (leave a blank line...
+##                          <--  or two blank lines before a new section)
+##
+## Leave properties that you do not wish to overrride commented-out with a single '#' and set to
+## the default value (for reference).
+##
+hibernate.connection.url=jdbc:mysql://127.0.0.1:3306/uportal
+hibernate.dialect = org.apereo.portal.utils.hibernate4.dialects.MySQL5InnoDBCompressedDialect
+
+################################################################################
+##                                                                            ##
+##                               Authentication                               ##
+##                                                                            ##
+################################################################################
+
+##
+## Portal Server
+##
+#portal.protocol=http
+#portal.server=localhost:8080
+#portal.context=/uPortal
+
+##
+## Central Authentication Service (CAS)
+##
+#cas.protocol=http
+#cas.server=localhost:8080
+#cas.context=/cas
+#cas.ticketValidationFilter.service=${portal.protocol}://${portal.server}${portal.context}/Login
+#cas.ticketValidationFilter.proxyReceptorUrl=/CasProxyServlet
+#cas.ticketValidationFilter.ticketValidator.server=${cas.protocol}://${cas.server}${cas.context}
+#cas.ticketValidationFilter.ticketValidator.proxyCallbackUrl=${portal.protocol}://${portal.server}${portal.context}/CasProxyServlet
+org.apereo.portal.security.provider.cas.CasAssertionSecurityContextFactory.enabled=true
+#org.apereo.portal.security.provider.cas.CasAssertionSecurityContextFactory.credentialToken=ticket
+
+##
+## Remote User (Shibboleth, etc.)
+##
+#org.apereo.portal.security.provider.RemoteUserSecurityContextFactory.enabled=false
+
+##
+## LDAP
+##
+#org.apereo.portal.security.provider.SimpleLdapSecurityContextFactory.enabled=false
+#org.apereo.portal.security.provider.SimpleLdapSecurityContextFactory.principalToken=userName
+#org.apereo.portal.security.provider.SimpleLdapSecurityContextFactory.credentialToken=password
+
+##
+## Simple (database)
+##
+org.apereo.portal.security.provider.SimpleSecurityContextFactory.enabled=true
+#org.apereo.portal.security.provider.SimpleSecurityContextFactory.principalToken=userName
+#org.apereo.portal.security.provider.SimpleSecurityContextFactory.credentialToken=password
+
+##
+## Destination of the Sign On button
+##
+#org.apereo.portal.channels.CLogin.CasLoginUrl=${cas.protocol}://${cas.server}${cas.context}/login?service=${portal.protocol}://${portal.server}${portal.context}/Login
+
+##
+## Where should users be redirected when they log out?
+##
+#logout.redirect=${cas.protocol}://${cas.server}${cas.context}/logout?url=${portal.protocol}://${portal.server}${portal.context}/Login
+
+
+################################################################################
+##                                                                            ##
+##                              User Attributes                               ##
+##                                                                            ##
+################################################################################
+
+##
+## LDAP connection settings for the defaultLdapContext bean, which is typically used to retrieve
+## user attributes from an LDAP directory.  The 'ldap.defaultLdapContext.user' property must be a
+## fully-qualified DN.
+##
+#ldap.defaultLdapContext.url=
+#ldap.defaultLdapContext.baseDn=
+#ldap.defaultLdapContext.user=
+#ldap.defaultLdapContext.password=
+
+################################################################################
+##                                                                            ##
+##                                  Security                                  ##
+##                                                                            ##
+################################################################################
+
+##
+## Encryption key for the String Encryption Service used for user password encryption (if
+## applicable).  This property should be set to different value, at least in server deployments.
+##
+#org.apereo.portal.portlets.passwordEncryptionKey=changeme
+
+##
+## Whitelist of origins that can make POSTs to uPortal endpoints.
+## Often set to CAS or IDP servers.
+## Origins should include protocol, and can be a comma-delimited list.
+#cors.allowed.origins=https://idp.myschool.edu, https://cas.myschool.edu
+
+
+################################################################################
+##                                                                            ##
+##                                  Soffits                                   ##
+##                                                                            ##
+################################################################################
+
+## Key for signing JSON Web Tokens (JWTs) in Soffits.  This property should be changed to an
+## institution- or environment-specific value.
+##
+#org.apereo.portal.soffit.jwt.signatureKey=CHANGEME
+
+## Key for encrypting JSON Web Tokens (JWTs) in Soffits.  This property should be changed to an
+## institution- or environment-specific value.
+##
+#org.apereo.portal.soffit.jwt.encryptionPassword=CHANGEME

--- a/docs/database/README.md
+++ b/docs/database/README.md
@@ -57,8 +57,7 @@ environment.build.hibernate.connection.validationQuery=select 1
 
 ## Step 4: Copy `global.properties` to local environment location and add credentials and URL
 
-In uPortal 5, deployers are strongly encouraged to configure a local `portal.home` directory to keep configuration
-that is specific to the environment but should not be captured in a repo. In particular, database and other service
+In uPortal 5, deployers are strongly encouraged to configure a local `portal.home` directory to keep configuration that is specific to the environment but should not be captured in a repo. In particular, database and other service
 credentials should not be captured. If `portal.home` is not configured, the default is the portal/ directory in Tomcat.
 
 During `./gradlew portalInit` or `./gradlew tomcatInstall`, the files from the repo's `etc/portal/` directory are
@@ -74,6 +73,17 @@ environment.build.hibernate.connection.password=[actual password for this db]
 environment.build.hibernate.dialect=org.hibernate.dialect.SQLServerDialect
 environment.build.hibernate.connection.validationQuery=select 1
 ```
+
+## Step 5: Specific portlet / uPortal database configuration (optional)
+
+The default configuration come from the file `global.properties` in the `portal.home` directory to deploy all applications.
+But it's possible to define a specific configuration per application/portlet, the `global.properties` will be always used but it could be overriden by a specific property file if found.
+
+For the uPortal database you will need to add database's' properties from `global.properties` into `uPortal.properties` file.
+For each portlets you should define same properties by adding the `specific-portlet.properties` into the `portal.home` directory, where `specific-portlet.properties` is the file name defined in the portlet spring context definition sources.
+As example, for `NewsReaderPortlet` the named file will be `news-reader.properties`, the file name can be found [in the NewsReaderPortlet project here.](https://github.com/Jasig/NewsReaderPortlet/blob/master/src/main/resources/context/databaseContext.xml)
+
+Note: Also these files can be used for other properties !
 
 ## uPortal Production Database Configuration 
 

--- a/docs/database/mariadb.md
+++ b/docs/database/mariadb.md
@@ -23,16 +23,22 @@ innodb_log_buffer_size=64M
 ```
 
 ## Step 2: Configure the user and database
-```properties
-mysql -uroot -p
 
+Connect to the database server.
+```SQL
 CREATE USER 'uportal'@'localhost' IDENTIFIED BY 'uportal';
-create database uportal CHARACTER SET utf8 COLLATE utf8_general_ci;
+create database uportal CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_520_ci;
 GRANT ALL PRIVILEGES ON uportal.* TO 'portail'@'localhost';
-# If you want to install portlets on an other database
-create database portlets CHARACTER SET utf8 COLLATE utf8_general_ci;
-GRANT ALL PRIVILEGES ON portlets.* TO 'portail'@'localhost';
+# If you want to install portlets on a specific database
+# create database portlet CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_520_ci;
+# GRANT ALL PRIVILEGES ON portlets.* TO 'portail'@'localhost';
 ```
+
+With MariaDb and Mysql the default character set should be set to `utf8mb4` instead of `utf8` as the mysql UTF-8 encoding is only a support of 3-bytes UTF-8 unicode encoding.
+The 3-bytes part is not a full UTF-8 support, this won't support Asian characters and emoticones files. [See here for more details](https://dev.mysql.com/doc/refman/5.5/en/charset-unicode.html)
+
+Also the collation `utf8mb4_unicode_520_ci` is a new best algorithm for ordering UTF-8 values, but you can stay on 'utf8_unicode_ci' [see the mysql documentation for details](https://dev.mysql.com/doc/refman/5.6/en/charset-collation-names.html)
+
 ## Step 3: Configure Uportal 
 
 ### Edit uPortal-start/gradle.properties 
@@ -62,17 +68,7 @@ hibernate.connection.password=uportal
 hibernate.connection.validationQuery=select 1
 hibernate.dialect = org.apereo.portal.utils.MySQL5InnoDBCompressedDialect
 ```
-### Edit uPortal-start/etc/portal/uPortal.properties
-**this step is needed only if you install portlets on a different database**
-
-```properties
-hibernate.connection.driver_class=com.mysql.jdbc.Driver
-hibernate.connection.url=jdbc:mysql://localhost/uportal
-hibernate.connection.username=uportal
-hibernate.connection.password=uportal
-hibernate.connection.validationQuery=select 1
-hibernate.dialect = org.apereo.portal.utils.MySQL5InnoDBCompressedDialect
-```
+You should copy/paste this configuration for each customized database portlet/uPortal context [see global datasource documentation](index.md#step-5-specific-portlet-uportal-database-configuration-optional)
 
 ## Step 4 : Initialization of the Database
 ```shell

--- a/docs/database/mariadb.md
+++ b/docs/database/mariadb.md
@@ -1,5 +1,7 @@
 # Configuration with MariaDB Database
 
+As working example you can watch on travis configuration test in `uPortal-start/.travis/conf/database/mariadb/`
+
 ## Step 1: MariaDB server setup
 Edit the file /etc/mysql/mariadb.conf.d/60-server.cnf. (Debian 9)
 In the [mysqld] part add the following items :

--- a/docs/database/mariadb.md
+++ b/docs/database/mariadb.md
@@ -1,10 +1,4 @@
-# MariaDB Database Configuration
-
-uPortal is configured to use a default HSQL database.
-
-**This database configuration is not suitable for production deployments but is better suited for testing purposes.**
-
-uPortal supports a number of production databases and you can configure the MariaDB database.
+# Configuration with MariaDB Database
 
 ## Step 1: MariaDB server setup
 Edit the file /etc/mysql/mariadb.conf.d/60-server.cnf. (Debian 9)
@@ -32,10 +26,11 @@ innodb_log_buffer_size=64M
 ```properties
 mysql -uroot -p
 
-MariaDB [(none)]> create database uportal CHARACTER SET utf8 COLLATE utf8_general_ci;
-MariaDB [(none)]> create database portlets CHARACTER SET utf8 COLLATE utf8_general_ci;
 CREATE USER 'uportal'@'localhost' IDENTIFIED BY 'uportal';
+create database uportal CHARACTER SET utf8 COLLATE utf8_general_ci;
 GRANT ALL PRIVILEGES ON uportal.* TO 'portail'@'localhost';
+# If you want to install portlets on an other database
+create database portlets CHARACTER SET utf8 COLLATE utf8_general_ci;
 GRANT ALL PRIVILEGES ON portlets.* TO 'portail'@'localhost';
 ```
 ## Step 3: Configure Uportal 
@@ -50,16 +45,10 @@ dependencies {
         /*
          * Add additional JDBC driver jars to the 'jdbc' configuration below;
          * do not remove the hsqldb driver jar that is already listed.
-         *
+         */
         jdbc "org.hsqldb:hsqldb:${hsqldbVersion}"
-        */
         jdbc "mysql:mysql-connector-java:${mysqldbVersion}"
         
-        /*
-         * These are nearly the same uPortal dependencies declared by uPortal-webapp;
-         * perhaps we should create a uPortal-all module to bundle them all as transitives.
-         */
-
 ```
 
 ### Edit uPortal-start/etc/portal/global.properties 
@@ -71,9 +60,10 @@ hibernate.connection.url=jdbc:mysql://localhost/portlets
 hibernate.connection.username=uportal
 hibernate.connection.password=uportal
 hibernate.connection.validationQuery=select 1
-hibernate.dialect = org.hibernate.dialect.MySQL5InnoDBDialect
+hibernate.dialect = org.apereo.portal.utils.MySQL5InnoDBCompressedDialect
 ```
 ### Edit uPortal-start/etc/portal/uPortal.properties
+**this step is needed only if you install portlets on a different database**
 
 ```properties
 hibernate.connection.driver_class=com.mysql.jdbc.Driver
@@ -81,7 +71,7 @@ hibernate.connection.url=jdbc:mysql://localhost/uportal
 hibernate.connection.username=uportal
 hibernate.connection.password=uportal
 hibernate.connection.validationQuery=select 1
-hibernate.dialect = org.hibernate.dialect.MySQL5InnoDBDialect
+hibernate.dialect = org.apereo.portal.utils.MySQL5InnoDBCompressedDialect
 ```
 
 ## Step 4 : Initialization of the Database

--- a/docs/database/mysql.md
+++ b/docs/database/mysql.md
@@ -1,0 +1,1 @@
+Until Mysql and MariaDB have the same server configuration you can watch on [MariaDB](mariadb.md) configuration !

--- a/docs/fr/database/README.md
+++ b/docs/fr/database/README.md
@@ -75,6 +75,17 @@ environment.build.hibernate.dialect=org.hibernate.dialect.SQLServerDialect
 environment.build.hibernate.connection.validationQuery=select 1
 ```
 
+## Étape 5: Configuration spécifique portlet / uPortal (optionel)
+
+La configuration utilisée par défaut pour déployer toutes les applications vient du fichier `global.properties` dans le répertoire `portal.home`.
+Mais il est tout à fait possible de définir une configuration par application/portlet, le fichier `global.properties` sera toujours utilisé mais il peut être surchargé par un fichier spécifique s'il est trouvé.
+
+Pour la base de données uPortal il sera nécessaire de recopier les mêmes propriétés de base de données du fichier `global.properties` dans le fichier `uPortal.properties`.
+Pour chaque portlet il faudra aussi redéfinir les mêmes propriétés en les ajoutant dans un fichier `specific-portlet.properties` du répertoire `portal.home`, où `specific-portlet.properties` est le nom du fichier défini dans les source de configurations de contexte spring du portlet.
+Par exemple, pour `NewsReaderPortlet` le fichier sera `news-reader.properties`, le nom du fichier à définir se trouvera [dans le projet NewsReaderPortlet ici.](https://github.com/Jasig/NewsReaderPortlet/blob/master/src/main/resources/context/databaseContext.xml)
+
+Remarque: Aussi ces fichiers peuvent être utilisés pour définir d'autres propriétés !
+
 ## Configuration de la base de données de production uPortal
 
 Sélectionner la base de données ci-dessous pour des notes et des exemples de configuration.

--- a/docs/fr/database/mariadb.md
+++ b/docs/fr/database/mariadb.md
@@ -23,16 +23,22 @@ innodb_log_buffer_size=64M
 ```
 
 ## Étape 2 : Configurer l'utilisateur et la base de donnée
-```properties
-mysql -uroot -p
 
+Se connecter au serveur de base de données.
+```SQL
 CREATE USER 'uportal'@'localhost' IDENTIFIED BY 'uportal';
-create database uportal CHARACTER SET utf8 COLLATE utf8_general_ci;
+create database uportal CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_520_ci;
 GRANT ALL PRIVILEGES ON uportal.* TO 'portail'@'localhost';
-# Si vous souhaitez installer les portlets sur une autre base de données spécifique.
-create database portlets CHARACTER SET utf8 COLLATE utf8_general_ci;
-GRANT ALL PRIVILEGES ON portlets.* TO 'portail'@'localhost';
+# If you want to install portlets on a specific database
+# create database portlet CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_520_ci;
+# GRANT ALL PRIVILEGES ON portlets.* TO 'portail'@'localhost';
 ```
+
+Avec MariaDB et MySQL le jeu de caractère par défaut doit être défini à `utf8mb4` au lieu de `utf8` car l'encodage UTF-8 de MySQL n'est qu'un support sur 3 octets (3-bytes) de l'encodage unicode.
+La partie sur 3 octets n'est pas un support complet de l'UTF-8, cela ne supportera pas les caractères Asiatiques ainsi que les émoticones. [Regarder ici pour plus de détails](https://dev.mysql.com/doc/refman/5.5/en/charset-unicode.html)
+
+Aussi la collation `utf8mb4_unicode_520_ci` est un nouvel et bon algorithme pour ordonner les données en UTF-8, mais vous pouvez tout aussi bien rester sur 'utf8_unicode_ci' [Regarder la documentation MySQL pour les détails](https://dev.mysql.com/doc/refman/5.6/en/charset-collation-names.html)
+
 ## Étape 3 : Configurer Uportal 
 
 ### Éditer uPortal-start/gradle.properties 
@@ -62,17 +68,8 @@ hibernate.connection.password=uportal
 hibernate.connection.validationQuery=select 1
 hibernate.dialect = org.apereo.portal.utils.MySQL5InnoDBCompressedDialect
 ```
-### Éditer uPortal-start/etc/portal/uPortal.properties
-**Cette étape est nécessaire uniquement si vous souhaitez dissocier l'installation des portlets sur une autre base de données.'**
 
-```properties
-hibernate.connection.driver_class=com.mysql.jdbc.Driver
-hibernate.connection.url=jdbc:mysql://localhost/uportal
-hibernate.connection.username=uportal
-hibernate.connection.password=uportal
-hibernate.connection.validationQuery=select 1
-hibernate.dialect = org.apereo.portal.utils.MySQL5InnoDBCompressedDialect
-```
+Vous devez copier/coller cette configuration pour chaque personnalisation d'accès à la base de données des contextes portlets / uPortal [cf configuration générale des bases de données](index.md#step-5-specific-portlet-uportal-database-configuration-optional)
 
 ## Étape 4 : Initialisation de la Base de Donnée
 ```shell

--- a/docs/fr/database/mariadb.md
+++ b/docs/fr/database/mariadb.md
@@ -1,10 +1,4 @@
-# Configuration de la Base de Données MariaDB
-
-uPortal est configuré pour utiliser une base de données HSQL par défaut.
-
-**Cette configuration de base de données ne convient pas aux déploiements de production mais est mieux adaptée à des fins de test.**
-
-uPortal prend en charge un certain nombre de bases de données de production et vous pouvez configurer la base de données MariaDB.
+# Configuration avec une Base de Données MariaDB
 
 ## Étape 1 : Paramétrage du server MariaDB
 Editer le fichier /etc/mysql/mariadb.conf.d/60-server.cnf. (ici pour Debian 9)
@@ -32,10 +26,11 @@ innodb_log_buffer_size=64M
 ```properties
 mysql -uroot -p
 
-MariaDB [(none)]> create database uportal CHARACTER SET utf8 COLLATE utf8_general_ci;
-MariaDB [(none)]> create database portlets CHARACTER SET utf8 COLLATE utf8_general_ci;
 CREATE USER 'uportal'@'localhost' IDENTIFIED BY 'uportal';
+create database uportal CHARACTER SET utf8 COLLATE utf8_general_ci;
 GRANT ALL PRIVILEGES ON uportal.* TO 'portail'@'localhost';
+# Si vous souhaitez installer les portlets sur une autre base de données spécifique.
+create database portlets CHARACTER SET utf8 COLLATE utf8_general_ci;
 GRANT ALL PRIVILEGES ON portlets.* TO 'portail'@'localhost';
 ```
 ## Étape 3 : Configurer Uportal 
@@ -50,15 +45,9 @@ dependencies {
         /*
          * Add additional JDBC driver jars to the 'jdbc' configuration below;
          * do not remove the hsqldb driver jar that is already listed.
-         *
-        jdbc "org.hsqldb:hsqldb:${hsqldbVersion}"
-        */
-        jdbc "mysql:mysql-connector-java:${mysqldbVersion}"
-        
-        /*
-         * These are nearly the same uPortal dependencies declared by uPortal-webapp;
-         * perhaps we should create a uPortal-all module to bundle them all as transitives.
          */
+        jdbc "org.hsqldb:hsqldb:${hsqldbVersion}"
+        jdbc "mysql:mysql-connector-java:${mysqldbVersion}"
 
 ```
 
@@ -71,9 +60,10 @@ hibernate.connection.url=jdbc:mysql://localhost/portlets
 hibernate.connection.username=uportal
 hibernate.connection.password=uportal
 hibernate.connection.validationQuery=select 1
-hibernate.dialect = org.hibernate.dialect.MySQL5InnoDBDialect
+hibernate.dialect = org.apereo.portal.utils.MySQL5InnoDBCompressedDialect
 ```
 ### Éditer uPortal-start/etc/portal/uPortal.properties
+**Cette étape est nécessaire uniquement si vous souhaitez dissocier l'installation des portlets sur une autre base de données.'**
 
 ```properties
 hibernate.connection.driver_class=com.mysql.jdbc.Driver
@@ -81,7 +71,7 @@ hibernate.connection.url=jdbc:mysql://localhost/uportal
 hibernate.connection.username=uportal
 hibernate.connection.password=uportal
 hibernate.connection.validationQuery=select 1
-hibernate.dialect = org.hibernate.dialect.MySQL5InnoDBDialect
+hibernate.dialect = org.apereo.portal.utils.MySQL5InnoDBCompressedDialect
 ```
 
 ## Étape 4 : Initialisation de la Base de Donnée

--- a/docs/fr/database/mariadb.md
+++ b/docs/fr/database/mariadb.md
@@ -1,5 +1,7 @@
 # Configuration avec une Base de Données MariaDB
 
+En exemple fonctionnel vous pouvez regarder les fichiers de configuration des test travis dans `uPortal-start/.travis/conf/database/mariadb/`
+
 ## Étape 1 : Paramétrage du server MariaDB
 Editer le fichier /etc/mysql/mariadb.conf.d/60-server.cnf. (ici pour Debian 9)
 Dans la partie mysqld ajouter les éléments suivant :

--- a/docs/fr/database/mysql.md
+++ b/docs/fr/database/mysql.md
@@ -1,1 +1,1 @@
-﻿
+﻿Tant que Mysql et MariaDB ont des configurations serveur similaires vous pouvez utiliser la configuration de [MariaDB](mariadb.md) !

--- a/overlays/Announcements/build.gradle
+++ b/overlays/Announcements/build.gradle
@@ -39,6 +39,8 @@ dependencies {
     impexp configurations.jdbc
     impexp "${portletApiDependency}"
     impexp "${servletApiDependency}"
+
+    jdbc "org.jasig.portal:uPortal-hibernate3-dialects:${uPortalVersion}"
 }
 
 dataInit {

--- a/overlays/BookmarksPortlet/build.gradle
+++ b/overlays/BookmarksPortlet/build.gradle
@@ -5,6 +5,7 @@ apply plugin: GradlePlutoPlugin
 dependencies {
     runtime "org.jasig.portlet:BookmarksPortlet:${bookmarksPortletVersion}@war"
     compile configurations.jdbc
+    jdbc "org.jasig.portal:uPortal-hibernate3-dialects:${uPortalVersion}"
 }
 
 war {

--- a/overlays/CalendarPortlet/build.gradle
+++ b/overlays/CalendarPortlet/build.gradle
@@ -39,6 +39,8 @@ dependencies {
     impexp configurations.jdbc
     impexp "${portletApiDependency}"
     impexp "${servletApiDependency}"
+
+    jdbc "org.jasig.portal:uPortal-hibernate3-dialects:${uPortalVersion}"
 }
 
 dataInit {

--- a/overlays/NewsReaderPortlet/build.gradle
+++ b/overlays/NewsReaderPortlet/build.gradle
@@ -7,6 +7,7 @@ apply plugin: GradlePlutoPlugin
 dependencies {
     runtime "org.jasig.portlet:NewsReaderPortlet:${newsReaderPortletVersion}@war"
     compile configurations.jdbc
+    jdbc "org.jasig.portal:uPortal-hibernate3-dialects:${uPortalVersion}"
 }
 
 war {

--- a/overlays/SimpleContentPortlet/build.gradle
+++ b/overlays/SimpleContentPortlet/build.gradle
@@ -7,6 +7,7 @@ apply plugin: GradlePlutoPlugin
 dependencies {
     runtime "org.jasig.portlet.simplecontent:SimpleContentPortlet:${simpleContentPortletVersion}@war"
     compile configurations.jdbc
+    jdbc "org.jasig.portal:uPortal-hibernate4-dialects:${uPortalVersion}"
 }
 
 war {

--- a/overlays/build.gradle
+++ b/overlays/build.gradle
@@ -46,6 +46,14 @@ subprojects {
         jdbc "org.hsqldb:hsqldb:${hsqldbVersion}"
 
         /*
+         * This dependency is needed for mysql/mariadb to be able to use the dialect org.apereo.portal.utils.MySQL5InnoDBCompressedDialect
+         */
+        jdbc ("org.jasig.portal:uPortal-utils-core:${uPortalVersion}") {
+            transitive = false
+        }
+        jdbc "org.hibernate:hibernate-core:${hibernateVersion}"
+
+        /*
          * These are nearly the same uPortal dependencies declared by uPortal-webapp;
          * perhaps we should create a uPortal-all module to bundle them all as transitives.
          */

--- a/overlays/build.gradle
+++ b/overlays/build.gradle
@@ -46,14 +46,6 @@ subprojects {
         jdbc "org.hsqldb:hsqldb:${hsqldbVersion}"
 
         /*
-         * This dependency is needed for mysql/mariadb to be able to use the dialect org.apereo.portal.utils.MySQL5InnoDBCompressedDialect
-         */
-        jdbc ("org.jasig.portal:uPortal-utils-core:${uPortalVersion}") {
-            transitive = false
-        }
-        jdbc "org.hibernate:hibernate-core:${hibernateVersion}"
-
-        /*
          * These are nearly the same uPortal dependencies declared by uPortal-webapp;
          * perhaps we should create a uPortal-all module to bundle them all as transitives.
          */


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.

Bug fixes and new features should be reported on the issue tracker: https://issues.jasig.org/browse/UP/

Contributors guide: https://github.com/Jasig/uPortal/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

-   [x] the [individual contributor license agreement][] is signed
-   [x] commit message follows [commit guidelines][]
-   [x] tests are included
-   [x] documentation is changed or added
-   [ ] [message properties][] have been updated with new phrases
-   [ ] view conforms with [WCAG 2.0 AA][]

##### Description of change
<!-- Provide a description of the change below this comment. -->

Adding dependency management for dataInit of all applications (uPortal and all portlets) on MariaDB (can work for MySQL) with the documentation and travis test on MariaDB.

This commit depends on https://github.com/Jasig/uPortal/pull/1176, which define two specifics dependencies that must be deployed on OSS Sonatype before.

<!-- Reference Links -->

[individual contributor license agreement]: https://github.com/Jasig/uPortal/blob/master/CONTRIBUTING.md#individual-contributor-license-agreement
[commit guidelines]: https://github.com/Jasig/uPortal/blob/master/CONTRIBUTING.md#commit
[message properties]: https://github.com/Jasig/uPortal/tree/master/uportal-war/src/main/resources/properties/i18n
[WCAG 2.0 AA]: https://www.w3.org/WAI/WCAG20/quickref/?levels=aaa&technologies=smil%2Cpdf%2Cflash%2Csl
