### PR TITLE
build(gradle): allow generation of project files to intellij and eclipse

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -8,6 +8,10 @@ plugins {
     id 'build-announcements'
 }
 
+// support integration with intellij and eclipse
+apply plugin: 'idea'
+apply plugin: 'eclipse'
+
 ext {
     /*
      * We need to define the buildProperties extended property here in order for the
@@ -37,7 +41,7 @@ apply from: rootProject.file('gradle/tasks/portlet.gradle')
 apply from: rootProject.file('gradle/tasks/docker.gradle')
 
 /*
- * Before compiling Java, ensure the Java version is correct.  
+ * Before compiling Java, ensure the Java version is correct.
  */
 apply plugin: 'java'
 compileJava {


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.

Bug fixes and new features should be reported on the issue tracker: https://issues.jasig.org/browse/UP/

Contributors guide: https://github.com/Jasig/uPortal/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

-   [x] the [individual contributor license agreement][] is signed
-   [x] commit message follows [commit guidelines][]

##### Description of change
<!-- Provide a description of the change below this comment. -->

Make it easier to setup uPortal-start with Eclipse and Intellij

<!-- Reference Links -->

[individual contributor license agreement]: https://github.com/Jasig/uPortal/blob/master/CONTRIBUTING.md#individual-contributor-license-agreement
[commit guidelines]: https://github.com/Jasig/uPortal/blob/master/CONTRIBUTING.md#commit
[message properties]: https://github.com/Jasig/uPortal/tree/master/uportal-war/src/main/resources/properties/i18n
[WCAG 2.0 AA]: https://www.w3.org/WAI/WCAG20/quickref/?levels=aaa&technologies=smil%2Cpdf%2Cflash%2Csl
