### PR TITLE
Added a task to reinstall the appropriate shared libraries for uPortal

### DIFF
--- a/gradle/tasks/tomcat.gradle
+++ b/gradle/tasks/tomcat.gradle
@@ -218,3 +218,22 @@ task tomcatTar {
         }
     }
 }
+
+task tomcatInstallShared() {
+    group 'Tomcat'
+    description 'Add shared.loader dependencies'
+    dependsOn ':portalProperties'
+
+    doLast {
+        String serverHome = rootProject.ext['buildProperties'].getProperty('server.home')
+
+        File tomcatSharedDir = new File("${serverHome}/shared/lib")
+
+        tomcatSharedDir.deleteDir()
+
+        copy {
+            from configurations.shared
+            into tomcatSharedDir
+        }
+    }
+}


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.

Bug fixes and new features should be reported on the issue tracker: https://issues.jasig.org/browse/UP/

Contributors guide: https://github.com/Jasig/uPortal/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

-   [x] the [individual contributor license agreement][] is signed
-   [x] commit message follows [commit guidelines][]
<!-- -   [ ] tests are included
-   [ ] documentation is changed or added
-   [ ] [message properties][] have been updated with new phrases
-   [ ] view conforms with [WCAG 2.0 AA][] -->

##### Description of change
<!-- Provide a description of the change below this comment. -->
When updating to a new release of uPortal, the shared libraries are not updated unless `tomcatInstall` is executed. One may not want to execute that task because it will blow everything in `server.home` away which is not desirable. 

The `tomcatInstallShared` will simply delete `${server.home}/shared/lib` and reload it with the appropriate shared libraries for uPortal.

Feel free to edit this to taste

<!-- Reference Links -->

[individual contributor license agreement]: https://github.com/Jasig/uPortal/blob/master/CONTRIBUTING.md#individual-contributor-license-agreement
[commit guidelines]: https://github.com/Jasig/uPortal/blob/master/CONTRIBUTING.md#commit
[message properties]: https://github.com/Jasig/uPortal/tree/master/uportal-war/src/main/resources/properties/i18n
[WCAG 2.0 AA]: https://www.w3.org/WAI/WCAG20/quickref/?levels=aaa&technologies=smil%2Cpdf%2Cflash%2Csl
