### PR TITLE
Possibility to set PORTAL_HOME in tomcatStart task from cmd

### DIFF
--- a/gradle/tasks/properties.gradle
+++ b/gradle/tasks/properties.gradle
@@ -68,7 +68,8 @@ task portalProperties() {
         }
 
         /*
-         * Step Three:  if CATALINA_HOME, CATALINA_BASE, and/or PORTAL_HOME are set, honor them now.
+         * Step Three:  if CATALINA_HOME, CATALINA_BASE, and/or PORTAL_HOME environment variables
+         * are set, honor them now.
          */
         if (System.getenv('CATALINA_HOME')) {
             buildProperties.setProperty('server.home', System.getenv('CATALINA_HOME'))

--- a/gradle/tasks/tomcat.gradle
+++ b/gradle/tasks/tomcat.gradle
@@ -116,9 +116,11 @@ task tomcatStart() {
         verifyTomcatState(project, false)
 
         String serverHome = rootProject.ext['buildProperties'].getProperty('server.home')
+        String portalHome = rootProject.ext['buildProperties'].getProperty('portal.home')
         logger.lifecycle("Starting Tomcat servlet container in ${serverHome}")
         String executable = isWindows ? 'cmd' : './catalina.sh'
         ant.exec(dir: "${serverHome}/bin", executable: executable, spawn: true) {
+            env(key: "PORTAL_HOME", value: portalHome)
             if (isWindows) {
                 arg(value: '/c')
                 arg(value: 'catalina.bat')


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.

Bug fixes and new features should be reported on the issue tracker: https://issues.jasig.org/browse/UP/

Contributors guide: https://github.com/Jasig/uPortal/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

-   [x] the [individual contributor license agreement][] is signed
-   [x] commit message follows [commit guidelines][]
-   [ ] tests are included
-   [ ] documentation is changed or added
-   [ ] [message properties][] have been updated with new phrases
-   [ ] view conforms with [WCAG 2.0 AA][]

##### Description of change
<!-- Provide a description of the change below this comment. -->
Provide a way to set the PORTAL_HOME env variable from uPortal-start task tomcatStart, also it permit to override the default value by passing -Dportal.home=path dynamically from command line.
It avoids to set PORTAL_HOME environment variable whereas we can pass it from command line in some case. With this change this permit to apply the portal.home value in all task.

An other improvement would be to add into java env all -D args passed from command line. (but seems complicated with gradle)

<!-- Reference Links -->

[individual contributor license agreement]: https://github.com/Jasig/uPortal/blob/master/CONTRIBUTING.md#individual-contributor-license-agreement
[commit guidelines]: https://github.com/Jasig/uPortal/blob/master/CONTRIBUTING.md#commit
[message properties]: https://github.com/Jasig/uPortal/tree/master/uportal-war/src/main/resources/properties/i18n
[WCAG 2.0 AA]: https://www.w3.org/WAI/WCAG20/quickref/?levels=aaa&technologies=smil%2Cpdf%2Cflash%2Csl
