### PR TITLE
Added support for custom Gradle tasks

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -41,6 +41,16 @@ apply from: rootProject.file('gradle/tasks/portlet.gradle')
 apply from: rootProject.file('gradle/tasks/docker.gradle')
 
 /*
+ * If gradle/tasks/custom.gradle exists, tasks from that
+ * file will be made available
+ */
+File customTasks = rootProject.file('gradle/tasks/custom.gradle')
+
+if(customTasks.isFile()) {
+    apply from: customTasks
+}
+
+/*
  * Before compiling Java, ensure the Java version is correct.
  */
 apply plugin: 'java'


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.

Bug fixes and new features should be reported on the issue tracker: https://issues.jasig.org/browse/UP/

Contributors guide: https://github.com/Jasig/uPortal/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

-   [x] the [individual contributor license agreement][] is signed
-   [x] commit message follows [commit guidelines][]

##### Description of change
<!-- Provide a description of the change below this comment. -->
This patch adds support for custom Gradle tasks (such as #156) that are not (yet) a part of uPortal-start. 

I'm trying to keep our modifications to our fork uPortal-start limited as much as possible and I think this will add some flexibility without having to worry about resolving merge conflicts in the future.

<!-- Reference Links -->

[individual contributor license agreement]: https://github.com/Jasig/uPortal/blob/master/.github/CONTRIBUTING.md#individual-contributor-license-agreement
[commit guidelines]: https://github.com/Jasig/uPortal/blob/master/.github/CONTRIBUTING.md#commit
[message properties]: https://github.com/Jasig/uPortal/tree/master/uportal-war/src/main/resources/properties/i18n
[WCAG 2.0 AA]: https://www.w3.org/WAI/WCAG20/quickref/?levels=aaa&technologies=smil%2Cpdf%2Cflash%2Csl
