### PR TITLE
feat:  add/update entities within the quickstart data set to showcase…

### DIFF
--- a/data/base/group_membership/Quicklinks.group-membership.xml
+++ b/data/base/group_membership/Quicklinks.group-membership.xml
@@ -20,17 +20,9 @@
 
 -->
 <group script="classpath://org/jasig/portal/io/import-group_membership_v3-2.crn">
-  <name>All categories</name>
+  <name>Quicklinks</name>
   <entity-type>org.apereo.portal.portlet.om.IPortletDefinition</entity-type>
   <creator>system</creator>
-  <description>All channel categories</description>
-  <children>
-    <group>Administration</group>
-    <group>Development</group>
-    <group>Featured</group>
-    <group>Information</group>
-    <group>Quicklinks</group>
-    <group>Tenant Portlets</group>
-    <group>uPortal</group>
-  </children>
+  <description>Portlets that may appear in an alternative navigation scheme, such as a Waffle Menu component</description>
+  <children/>
 </group>

--- a/data/base/portlet-definition/directory.portlet-definition.xml
+++ b/data/base/portlet-definition/directory.portlet-definition.xml
@@ -31,6 +31,7 @@
         <ns2:portletName>Directory</ns2:portletName>
     </portlet-descriptor>
     <category>Information</category>
+    <category>Quicklinks</category>
     <group>Authenticated Users</group>
     <permissions>
         <permission system="UP_PORTLET_SUBSCRIBE" activity="BROWSE">

--- a/data/base/portlet-definition/favorites.portlet-definition.xml
+++ b/data/base/portlet-definition/favorites.portlet-definition.xml
@@ -30,6 +30,7 @@
         <ns2:isFramework>true</ns2:isFramework>
         <ns2:portletName>Favorites</ns2:portletName>
     </portlet-descriptor>
+    <category>Quicklinks</category>
     <category>uPortal</category>
     <group>Everyone</group>
     <permissions>

--- a/data/base/portlet-definition/reset-my-layout.portlet-definition.xml
+++ b/data/base/portlet-definition/reset-my-layout.portlet-definition.xml
@@ -31,6 +31,7 @@
         <ns2:portletName>ResetMyLayout</ns2:portletName>
     </portlet-descriptor>
     <category>Administration</category>
+    <category>Quicklinks</category>
     <group>Authenticated Users</group>
     <permissions>
         <permission system="UP_PORTLET_SUBSCRIBE" activity="BROWSE">

--- a/data/quickstart/fragment-layout/authenticated-lo.fragment-layout.xml
+++ b/data/quickstart/fragment-layout/authenticated-lo.fragment-layout.xml
@@ -48,5 +48,8 @@
             <channel fname="personalization-gallery" unremovable="false" hidden="false" immutable="false" ID="n310"/>
             <channel fname="background-preference" unremovable="true" hidden="false" immutable="false" ID="n320"/>
         </folder>
+        <folder ID="s400" hidden="false" immutable="true" name="Post Content folder" type="post-content" unremovable="true">
+            <channel fname="favorites-carousel" unremovable="false" hidden="false" immutable="false" ID="n410"/>
+        </folder>
     </folder>
 </layout>

--- a/data/quickstart/fragment-layout/authenticated-lo.fragment-layout.xml
+++ b/data/quickstart/fragment-layout/authenticated-lo.fragment-layout.xml
@@ -38,10 +38,11 @@
             <channel fname="personalization-gallery" unremovable="false" hidden="false" immutable="false" ID="n42"/>
         </folder> -->
         <folder ID="s100" hidden="false" immutable="true" name="Eyebrow folder" type="eyebrow" unremovable="true">
-            <channel fname="notification-icon" unremovable="false" hidden="false" immutable="false" ID="n110"/>
-            <channel fname="portal-greeting" unremovable="false" hidden="false" immutable="false" ID="n120"/>
-            <channel fname="logout-launcher" unremovable="false" hidden="false" immutable="false" ID="n130"/>
-            <channel fname="session-timeout" unremovable="false" hidden="false" immutable="false" ID="n140"/>
+            <channel fname="waffle-menu" unremovable="false" hidden="false" immutable="false" ID="n110"/>
+            <channel fname="notification-icon" unremovable="false" hidden="false" immutable="false" ID="n120"/>
+            <channel fname="portal-greeting" unremovable="false" hidden="false" immutable="false" ID="n130"/>
+            <channel fname="logout-launcher" unremovable="false" hidden="false" immutable="false" ID="n140"/>
+            <channel fname="session-timeout" unremovable="false" hidden="false" immutable="false" ID="n150"/>
         </folder>
         <folder ID="s300" hidden="false" immutable="true" name="Customize folder" type="customize" unremovable="true">
             <channel fname="personalization-gallery" unremovable="false" hidden="false" immutable="false" ID="n310"/>

--- a/data/quickstart/fragment-layout/authenticated-lo.fragment-layout.xml
+++ b/data/quickstart/fragment-layout/authenticated-lo.fragment-layout.xml
@@ -48,8 +48,5 @@
             <channel fname="personalization-gallery" unremovable="false" hidden="false" immutable="false" ID="n310"/>
             <channel fname="background-preference" unremovable="true" hidden="false" immutable="false" ID="n320"/>
         </folder>
-        <folder ID="s400" hidden="false" immutable="true" name="Post Content folder" type="post-content" unremovable="true">
-            <channel fname="favorites-carousel" unremovable="false" hidden="false" immutable="false" ID="n410"/>
-        </folder>
     </folder>
 </layout>

--- a/data/quickstart/group_membership/All_categories.group-membership.xml
+++ b/data/quickstart/group_membership/All_categories.group-membership.xml
@@ -36,11 +36,12 @@
     <group>Instructors</group>
     <group>Library</group>
     <group>News</group>
+    <group>Quicklinks</group>
     <group>Research</group>
     <group>Services</group>
     <group>Tenant Portlets</group>
     <group>Testing</group>
-    <group>Work</group>
     <group>uPortal</group>
+    <group>Work</group>
   </children>
 </group>

--- a/data/quickstart/portlet-definition/browse-carousel-demo.portlet-definition.xml
+++ b/data/quickstart/portlet-definition/browse-carousel-demo.portlet-definition.xml
@@ -1,0 +1,92 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<!--
+
+    Licensed to Apereo under one or more contributor license
+    agreements. See the NOTICE file distributed with this work
+    for additional information regarding copyright ownership.
+    Apereo licenses this file to you under the Apache License,
+    Version 2.0 (the "License"); you may not use this file
+    except in compliance with the License.  You may obtain a
+    copy of the License at the following location:
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied.  See the License for the
+    specific language governing permissions and limitations
+    under the License.
+
+-->
+<portlet-definition xmlns="https://source.jasig.org/schemas/uportal/io/portlet-definition" xmlns:ns2="https://source.jasig.org/schemas/uportal" xmlns:ns3="https://source.jasig.org/schemas/uportal/io/stylesheet-descriptor" xmlns:ns4="https://source.jasig.org/schemas/uportal/io/permission-owner" xmlns:ns5="https://source.jasig.org/schemas/uportal/io/subscribed-fragment" xmlns:ns6="https://source.jasig.org/schemas/uportal/io/event-aggregation" xmlns:ns7="https://source.jasig.org/schemas/uportal/io/user" xmlns:ns8="https://source.jasig.org/schemas/uportal/io/portlet-type" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="4.0" xsi:schemaLocation="https://source.jasig.org/schemas/uportal/io/portlet-definition https://source.jasig.org/schemas/uportal/io/portlet-definition/portlet-definition-4.0.xsd">
+    <title>Browse Carousel Demo</title>
+    <name>Browse Carousel Demo</name>
+    <fname>browse-carousel-demo</fname>
+    <desc>Showcase the new Browse Carousel</desc>
+    <type>Advanced CMS</type>
+    <timeout>5000</timeout>
+    <portlet-descriptor>
+        <ns2:webAppName>/SimpleContentPortlet</ns2:webAppName>
+        <ns2:portletName>cms</ns2:portletName>
+    </portlet-descriptor>
+    <group>Everyone</group>
+    <parameter>
+        <name>alternate</name>
+        <value>false</value>
+    </parameter>
+    <parameter>
+        <name>blockImpersonation</name>
+        <value>false</value>
+    </parameter>
+    <parameter>
+        <name>disableDynamicTitle</name>
+        <value>true</value>
+    </parameter>
+    <parameter>
+        <name>editable</name>
+        <value>false</value>
+    </parameter>
+    <parameter>
+        <name>hasAbout</name>
+        <value>false</value>
+    </parameter>
+    <parameter>
+        <name>hasHelp</name>
+        <value>false</value>
+    </parameter>
+    <parameter>
+        <name>hideFromMobile</name>
+        <value>false</value>
+    </parameter>
+    <parameter>
+        <name>highlight</name>
+        <value>false</value>
+    </parameter>
+    <parameter>
+        <name>iconUrl</name>
+        <value>/ResourceServingWebapp/rs/tango/0.8.90/32x32/status/dialog-warning.png</value>
+    </parameter>
+    <parameter>
+        <name>mobileIconUrl</name>
+        <value>/uPortal/media/skins/icons/mobile/bullhorn.png</value>
+    </parameter>
+    <parameter>
+        <name>showChrome</name>
+        <value>true</value>
+    </parameter>
+<portlet-preference>
+    <name>content</name>
+    <readOnly>false</readOnly>
+    <value>
+        <![CDATA[
+            <script src="https://unpkg.com/vue@2.5.16"></script>
+            <script type="text/javascript" src="/resource-server/webjars/uportal__content-carousel/1.7.4/dist/content-carousel.js"></script>
+            <content-carousel
+                    type="portlet"
+                    source="/uPortal/api/v4-3/dlm/portletRegistry.json">
+            </content-carousel>
+        ]]><!-- slick-options="{ \"slidesToShow\": 6, \"infinite\": true, \"arrows\": true, \"dots\": true }" -->
+    </value>
+</portlet-preference>
+</portlet-definition>

--- a/data/quickstart/portlet-definition/browse-carousel-demo.portlet-definition.xml
+++ b/data/quickstart/portlet-definition/browse-carousel-demo.portlet-definition.xml
@@ -85,7 +85,7 @@
             <content-carousel
                     type="portlet"
                     source="/uPortal/api/v4-3/dlm/portletRegistry.json"
-                    slick-options="{ \"slidesToShow\": 6, \"infinite\": true, \"arrows\": true, \"dots\": true }">
+                    slick-options='{ "slidesToShow": 6, "infinite": true, "arrows": true, "dots": true }'>
             </content-carousel>
         ]]>
     </value>

--- a/data/quickstart/portlet-definition/browse-carousel-demo.portlet-definition.xml
+++ b/data/quickstart/portlet-definition/browse-carousel-demo.portlet-definition.xml
@@ -81,12 +81,13 @@
     <value>
         <![CDATA[
             <script src="https://unpkg.com/vue@2.5.16"></script>
-            <script type="text/javascript" src="/resource-server/webjars/uportal__content-carousel/1.7.4/dist/content-carousel.js"></script>
+            <script type="text/javascript" src="/resource-server/webjars/uportal__content-carousel/1.8.0/dist/content-carousel.js"></script>
             <content-carousel
                     type="portlet"
-                    source="/uPortal/api/v4-3/dlm/portletRegistry.json">
+                    source="/uPortal/api/v4-3/dlm/portletRegistry.json"
+                    slick-options="{ \"slidesToShow\": 6, \"infinite\": true, \"arrows\": true, \"dots\": true }">
             </content-carousel>
-        ]]><!-- slick-options="{ \"slidesToShow\": 6, \"infinite\": true, \"arrows\": true, \"dots\": true }" -->
+        ]]>
     </value>
 </portlet-preference>
 </portlet-definition>

--- a/data/quickstart/portlet-definition/courses.portlet-definition.xml
+++ b/data/quickstart/portlet-definition/courses.portlet-definition.xml
@@ -31,6 +31,7 @@
         <ns2:portletName>cms</ns2:portletName>
     </portlet-descriptor>
     <category>Academics</category>
+    <category>Quicklinks</category>
     <group>Everyone</group>
     <permissions>
         <permission system="UP_PORTLET_SUBSCRIBE" activity="BROWSE">

--- a/data/quickstart/portlet-definition/dictionary-portlet.portlet-definition.xml
+++ b/data/quickstart/portlet-definition/dictionary-portlet.portlet-definition.xml
@@ -31,6 +31,7 @@
         <ns2:portletName>dictionary</ns2:portletName>
     </portlet-descriptor>
     <category>Information</category>
+    <category>Quicklinks</category>
     <group>Everyone</group>
     <permissions>
         <permission system="UP_PORTLET_SUBSCRIBE" activity="BROWSE">

--- a/data/quickstart/portlet-definition/favorites-carousel.portlet-definition.xml
+++ b/data/quickstart/portlet-definition/favorites-carousel.portlet-definition.xml
@@ -65,7 +65,7 @@
         <value>
             <![CDATA[
                 <script src="https://unpkg.com/vue@2.5.16"></script>
-                <script type="text/javascript" src="/resource-server/webjars/uportal__content-carousel/1.11.1/dist/content-carousel.js"></script>
+                <script type="text/javascript" src="/resource-server/webjars/uportal__content-carousel/dist/content-carousel.js"></script>
                 <content-carousel
                         type="portlet"
                         source="/uPortal/api/v4-3/dlm/portletRegistry.json?favorite=true"

--- a/data/quickstart/portlet-definition/favorites-carousel.portlet-definition.xml
+++ b/data/quickstart/portlet-definition/favorites-carousel.portlet-definition.xml
@@ -65,7 +65,7 @@
         <value>
             <![CDATA[
                 <script src="https://unpkg.com/vue@2.5.16"></script>
-                <script type="text/javascript" src="/resource-server/webjars/uportal__content-carousel/1.10.1/dist/content-carousel.js"></script>
+                <script type="text/javascript" src="/resource-server/webjars/uportal__content-carousel/1.11.0/dist/content-carousel.js"></script>
                 <content-carousel
                         type="portlet"
                         source="/uPortal/api/v4-3/dlm/portletRegistry.json?favorite=true"

--- a/data/quickstart/portlet-definition/favorites-carousel.portlet-definition.xml
+++ b/data/quickstart/portlet-definition/favorites-carousel.portlet-definition.xml
@@ -65,7 +65,7 @@
         <value>
             <![CDATA[
                 <script src="https://unpkg.com/vue@2.5.16"></script>
-                <script type="text/javascript" src="/resource-server/webjars/uportal__content-carousel/1.8.0/dist/content-carousel.js"></script>
+                <script type="text/javascript" src="/resource-server/webjars/uportal__content-carousel/1.9.1/dist/content-carousel.js"></script>
                 <content-carousel
                         type="portlet"
                         source="/uPortal/api/v4-3/dlm/portletRegistry.json?favorite=true"

--- a/data/quickstart/portlet-definition/favorites-carousel.portlet-definition.xml
+++ b/data/quickstart/portlet-definition/favorites-carousel.portlet-definition.xml
@@ -70,6 +70,11 @@
                         type="portlet"
                         source="/uPortal/api/v4-3/dlm/portletRegistry.json?favorite=true"
                         slick-options='{ "slidesToShow": 6, "infinite": true, "arrows": true, "dots": true }'>
+                    <h3 slot="header">Favorites</h1>
+                    <div slot="empty">
+                        <h4>You don't have any favorites yet!</h4>
+                        <p>Use "Options &gt; Add to my favorites" to organize content here.</p>
+                    </div>
                 </content-carousel>
             ]]>
         </value>

--- a/data/quickstart/portlet-definition/favorites-carousel.portlet-definition.xml
+++ b/data/quickstart/portlet-definition/favorites-carousel.portlet-definition.xml
@@ -20,10 +20,10 @@
 
 -->
 <portlet-definition xmlns="https://source.jasig.org/schemas/uportal/io/portlet-definition" xmlns:ns2="https://source.jasig.org/schemas/uportal" xmlns:ns3="https://source.jasig.org/schemas/uportal/io/stylesheet-descriptor" xmlns:ns4="https://source.jasig.org/schemas/uportal/io/permission-owner" xmlns:ns5="https://source.jasig.org/schemas/uportal/io/subscribed-fragment" xmlns:ns6="https://source.jasig.org/schemas/uportal/io/event-aggregation" xmlns:ns7="https://source.jasig.org/schemas/uportal/io/user" xmlns:ns8="https://source.jasig.org/schemas/uportal/io/portlet-type" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="4.0" xsi:schemaLocation="https://source.jasig.org/schemas/uportal/io/portlet-definition https://source.jasig.org/schemas/uportal/io/portlet-definition/portlet-definition-4.0.xsd">
-    <title>Browse Carousel Demo</title>
-    <name>Browse Carousel Demo</name>
-    <fname>browse-carousel-demo</fname>
-    <desc>Showcase the new Browse Carousel</desc>
+    <title>Favorites Carousel</title>
+    <name>Favorites Carousel</name>
+    <fname>favorites-carousel</fname>
+    <desc>A carousel of portlets in the user's collection of favorites</desc>
     <type>Advanced CMS</type>
     <timeout>5000</timeout>
     <portlet-descriptor>
@@ -32,12 +32,12 @@
     </portlet-descriptor>
     <group>Everyone</group>
     <parameter>
-        <name>alternate</name>
+        <name>blockImpersonation</name>
         <value>false</value>
     </parameter>
     <parameter>
-        <name>blockImpersonation</name>
-        <value>false</value>
+        <name>chromeStyle</name>
+        <value>no-chrome</value>
     </parameter>
     <parameter>
         <name>disableDynamicTitle</name>
@@ -59,35 +59,19 @@
         <name>hideFromMobile</name>
         <value>false</value>
     </parameter>
-    <parameter>
-        <name>highlight</name>
-        <value>false</value>
-    </parameter>
-    <parameter>
-        <name>iconUrl</name>
-        <value>/ResourceServingWebapp/rs/tango/0.8.90/32x32/status/dialog-warning.png</value>
-    </parameter>
-    <parameter>
-        <name>mobileIconUrl</name>
-        <value>/uPortal/media/skins/icons/mobile/bullhorn.png</value>
-    </parameter>
-    <parameter>
-        <name>showChrome</name>
-        <value>true</value>
-    </parameter>
-<portlet-preference>
-    <name>content</name>
-    <readOnly>false</readOnly>
-    <value>
-        <![CDATA[
-            <script src="https://unpkg.com/vue@2.5.16"></script>
-            <script type="text/javascript" src="/resource-server/webjars/uportal__content-carousel/1.8.0/dist/content-carousel.js"></script>
-            <content-carousel
-                    type="portlet"
-                    source="/uPortal/api/v4-3/dlm/portletRegistry.json"
-                    slick-options='{ "slidesToShow": 6, "infinite": true, "arrows": true, "dots": true }'>
-            </content-carousel>
-        ]]>
-    </value>
-</portlet-preference>
+    <portlet-preference>
+        <name>content</name>
+        <readOnly>false</readOnly>
+        <value>
+            <![CDATA[
+                <script src="https://unpkg.com/vue@2.5.16"></script>
+                <script type="text/javascript" src="/resource-server/webjars/uportal__content-carousel/1.8.0/dist/content-carousel.js"></script>
+                <content-carousel
+                        type="portlet"
+                        source="/uPortal/api/v4-3/dlm/portletRegistry.json?favorite=true"
+                        slick-options='{ "slidesToShow": 6, "infinite": true, "arrows": true, "dots": true }'>
+                </content-carousel>
+            ]]>
+        </value>
+    </portlet-preference>
 </portlet-definition>

--- a/data/quickstart/portlet-definition/favorites-carousel.portlet-definition.xml
+++ b/data/quickstart/portlet-definition/favorites-carousel.portlet-definition.xml
@@ -65,7 +65,7 @@
         <value>
             <![CDATA[
                 <script src="https://unpkg.com/vue@2.5.16"></script>
-                <script type="text/javascript" src="/resource-server/webjars/uportal__content-carousel/1.11.0/dist/content-carousel.js"></script>
+                <script type="text/javascript" src="/resource-server/webjars/uportal__content-carousel/1.11.1/dist/content-carousel.js"></script>
                 <content-carousel
                         type="portlet"
                         source="/uPortal/api/v4-3/dlm/portletRegistry.json?favorite=true"

--- a/data/quickstart/portlet-definition/favorites-carousel.portlet-definition.xml
+++ b/data/quickstart/portlet-definition/favorites-carousel.portlet-definition.xml
@@ -70,7 +70,7 @@
                         type="portlet"
                         source="/uPortal/api/v4-3/dlm/portletRegistry.json?favorite=true"
                         slick-options='{ "slidesToShow": 6, "infinite": true, "arrows": true, "dots": true }'>
-                    <h3 slot="header">Favorites</h1>
+                    <h3 slot="header">Favorites</h3>
                     <div slot="empty">
                         <h4>You don't have any favorites yet!</h4>
                         <p>Use "Options &gt; Add to my favorites" to organize content here.</p>

--- a/data/quickstart/portlet-definition/favorites-carousel.portlet-definition.xml
+++ b/data/quickstart/portlet-definition/favorites-carousel.portlet-definition.xml
@@ -65,7 +65,7 @@
         <value>
             <![CDATA[
                 <script src="https://unpkg.com/vue@2.5.16"></script>
-                <script type="text/javascript" src="/resource-server/webjars/uportal__content-carousel/1.9.1/dist/content-carousel.js"></script>
+                <script type="text/javascript" src="/resource-server/webjars/uportal__content-carousel/1.10.1/dist/content-carousel.js"></script>
                 <content-carousel
                         type="portlet"
                         source="/uPortal/api/v4-3/dlm/portletRegistry.json?favorite=true"

--- a/data/quickstart/portlet-definition/movie-news.portlet-definition.xml
+++ b/data/quickstart/portlet-definition/movie-news.portlet-definition.xml
@@ -31,6 +31,7 @@
         <ns2:portletName>news</ns2:portletName>
     </portlet-descriptor>
     <category>Entertainment</category>
+    <category>Quicklinks</category>
     <group>Everyone</group>
     <permissions>
         <permission system="UP_PORTLET_SUBSCRIBE" activity="BROWSE">

--- a/data/quickstart/portlet-definition/uportal-links.portlet-definition.xml
+++ b/data/quickstart/portlet-definition/uportal-links.portlet-definition.xml
@@ -31,6 +31,7 @@
         <ns2:portletName>cms</ns2:portletName>
     </portlet-descriptor>
     <category>News</category>
+    <category>Quicklinks</category>
     <group>Everyone</group>
     <permissions>
         <permission system="UP_PORTLET_SUBSCRIBE" activity="BROWSE">

--- a/data/quickstart/portlet-definition/waffle-menu-demo.portlet-definition.xml
+++ b/data/quickstart/portlet-definition/waffle-menu-demo.portlet-definition.xml
@@ -1,0 +1,88 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<!--
+
+    Licensed to Apereo under one or more contributor license
+    agreements. See the NOTICE file distributed with this work
+    for additional information regarding copyright ownership.
+    Apereo licenses this file to you under the Apache License,
+    Version 2.0 (the "License"); you may not use this file
+    except in compliance with the License.  You may obtain a
+    copy of the License at the following location:
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied.  See the License for the
+    specific language governing permissions and limitations
+    under the License.
+
+-->
+<portlet-definition xmlns="https://source.jasig.org/schemas/uportal/io/portlet-definition" xmlns:ns2="https://source.jasig.org/schemas/uportal" xmlns:ns3="https://source.jasig.org/schemas/uportal/io/stylesheet-descriptor" xmlns:ns4="https://source.jasig.org/schemas/uportal/io/permission-owner" xmlns:ns5="https://source.jasig.org/schemas/uportal/io/subscribed-fragment" xmlns:ns6="https://source.jasig.org/schemas/uportal/io/event-aggregation" xmlns:ns7="https://source.jasig.org/schemas/uportal/io/user" xmlns:ns8="https://source.jasig.org/schemas/uportal/io/portlet-type" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="4.0" xsi:schemaLocation="https://source.jasig.org/schemas/uportal/io/portlet-definition https://source.jasig.org/schemas/uportal/io/portlet-definition/portlet-definition-4.0.xsd">
+    <title>Waffle Menu</title>
+    <name>Waffle Menu</name>
+    <fname>waffle-menu</fname>
+    <desc>Quick access to external applications in the Eyebrow region</desc>
+    <type>Advanced CMS</type>
+    <timeout>5000</timeout>
+    <portlet-descriptor>
+        <ns2:webAppName>/SimpleContentPortlet</ns2:webAppName>
+        <ns2:portletName>cms</ns2:portletName>
+    </portlet-descriptor>
+    <group>Everyone</group>
+    <parameter>
+        <name>alternate</name>
+        <value>false</value>
+    </parameter>
+    <parameter>
+        <name>blockImpersonation</name>
+        <value>false</value>
+    </parameter>
+    <parameter>
+        <name>disableDynamicTitle</name>
+        <value>true</value>
+    </parameter>
+    <parameter>
+        <name>editable</name>
+        <value>false</value>
+    </parameter>
+    <parameter>
+        <name>hasAbout</name>
+        <value>false</value>
+    </parameter>
+    <parameter>
+        <name>hasHelp</name>
+        <value>false</value>
+    </parameter>
+    <parameter>
+        <name>hideFromMobile</name>
+        <value>false</value>
+    </parameter>
+    <parameter>
+        <name>highlight</name>
+        <value>false</value>
+    </parameter>
+    <parameter>
+        <name>iconUrl</name>
+        <value>/ResourceServingWebapp/rs/tango/0.8.90/32x32/status/dialog-warning.png</value>
+    </parameter>
+    <parameter>
+        <name>mobileIconUrl</name>
+        <value>/uPortal/media/skins/icons/mobile/bullhorn.png</value>
+    </parameter>
+    <parameter>
+        <name>showChrome</name>
+        <value>true</value>
+    </parameter>
+<portlet-preference>
+    <name>content</name>
+    <readOnly>false</readOnly>
+    <value>
+        <![CDATA[
+            <script type="text/javascript" src="/resource-server/webjars/uportal__waffle-menu/1.7.4/build/static/js/waffle-menu.js"></script>
+            <waffle-menu url="/uPortal/api/v4-3/dlm/portletRegistry.json" />
+        ]]>
+    </value>
+</portlet-preference>
+</portlet-definition>

--- a/data/quickstart/portlet-definition/waffle-menu.portlet-definition.xml
+++ b/data/quickstart/portlet-definition/waffle-menu.portlet-definition.xml
@@ -80,7 +80,7 @@
     <readOnly>false</readOnly>
     <value>
         <![CDATA[
-            <script type="text/javascript" src="/resource-server/webjars/uportal__waffle-menu/1.8.0/build/static/js/waffle-menu.js"></script>
+            <script type="text/javascript" src="/resource-server/webjars/uportal__waffle-menu/1.9.1/build/static/js/waffle-menu.js"></script>
             <waffle-menu
                     url="/uPortal/api/v4-3/dlm/portletRegistry.json?category=Quicklinks"
                     style="font-size: 75%; position: relative; top: .25rem;" />

--- a/data/quickstart/portlet-definition/waffle-menu.portlet-definition.xml
+++ b/data/quickstart/portlet-definition/waffle-menu.portlet-definition.xml
@@ -80,7 +80,7 @@
     <readOnly>false</readOnly>
     <value>
         <![CDATA[
-            <script type="text/javascript" src="/resource-server/webjars/uportal__waffle-menu/1.11.0/build/static/js/waffle-menu.js"></script>
+            <script type="text/javascript" src="/resource-server/webjars/uportal__waffle-menu/1.11.1/build/static/js/waffle-menu.js"></script>
             <waffle-menu
                     url="/uPortal/api/v4-3/dlm/portletRegistry.json?category=Quicklinks"
                     style="font-size: 75%; position: relative; top: .25rem;" />

--- a/data/quickstart/portlet-definition/waffle-menu.portlet-definition.xml
+++ b/data/quickstart/portlet-definition/waffle-menu.portlet-definition.xml
@@ -80,7 +80,7 @@
     <readOnly>false</readOnly>
     <value>
         <![CDATA[
-            <script type="text/javascript" src="/resource-server/webjars/uportal__waffle-menu/1.10.1/build/static/js/waffle-menu.js"></script>
+            <script type="text/javascript" src="/resource-server/webjars/uportal__waffle-menu/1.11.0/build/static/js/waffle-menu.js"></script>
             <waffle-menu
                     url="/uPortal/api/v4-3/dlm/portletRegistry.json?category=Quicklinks"
                     style="font-size: 75%; position: relative; top: .25rem;" />

--- a/data/quickstart/portlet-definition/waffle-menu.portlet-definition.xml
+++ b/data/quickstart/portlet-definition/waffle-menu.portlet-definition.xml
@@ -80,7 +80,7 @@
     <readOnly>false</readOnly>
     <value>
         <![CDATA[
-            <script type="text/javascript" src="/resource-server/webjars/uportal__waffle-menu/1.11.1/build/static/js/waffle-menu.js"></script>
+            <script type="text/javascript" src="/resource-server/webjars/uportal__waffle-menu/build/static/js/waffle-menu.js"></script>
             <waffle-menu
                     url="/uPortal/api/v4-3/dlm/portletRegistry.json?category=Quicklinks"
                     style="font-size: 75%; position: relative; top: .25rem;" />

--- a/data/quickstart/portlet-definition/waffle-menu.portlet-definition.xml
+++ b/data/quickstart/portlet-definition/waffle-menu.portlet-definition.xml
@@ -81,7 +81,9 @@
     <value>
         <![CDATA[
             <script type="text/javascript" src="/resource-server/webjars/uportal__waffle-menu/1.8.0/build/static/js/waffle-menu.js"></script>
-            <waffle-menu url="/uPortal/api/v4-3/dlm/portletRegistry.json?category=Quicklinks" />
+            <waffle-menu
+                    url="/uPortal/api/v4-3/dlm/portletRegistry.json?category=Quicklinks"
+                    style="font-size: 75%; position: relative; top: .25rem;" />
         ]]>
     </value>
 </portlet-preference>

--- a/data/quickstart/portlet-definition/waffle-menu.portlet-definition.xml
+++ b/data/quickstart/portlet-definition/waffle-menu.portlet-definition.xml
@@ -80,8 +80,8 @@
     <readOnly>false</readOnly>
     <value>
         <![CDATA[
-            <script type="text/javascript" src="/resource-server/webjars/uportal__waffle-menu/1.7.4/build/static/js/waffle-menu.js"></script>
-            <waffle-menu url="/uPortal/api/v4-3/dlm/portletRegistry.json" />
+            <script type="text/javascript" src="/resource-server/webjars/uportal__waffle-menu/1.8.0/build/static/js/waffle-menu.js"></script>
+            <waffle-menu url="/uPortal/api/v4-3/dlm/portletRegistry.json?category=Quicklinks" />
         ]]>
     </value>
 </portlet-preference>

--- a/data/quickstart/portlet-definition/waffle-menu.portlet-definition.xml
+++ b/data/quickstart/portlet-definition/waffle-menu.portlet-definition.xml
@@ -80,7 +80,7 @@
     <readOnly>false</readOnly>
     <value>
         <![CDATA[
-            <script type="text/javascript" src="/resource-server/webjars/uportal__waffle-menu/1.9.1/build/static/js/waffle-menu.js"></script>
+            <script type="text/javascript" src="/resource-server/webjars/uportal__waffle-menu/1.10.1/build/static/js/waffle-menu.js"></script>
             <waffle-menu
                     url="/uPortal/api/v4-3/dlm/portletRegistry.json?category=Quicklinks"
                     style="font-size: 75%; position: relative; top: .25rem;" />

--- a/data/quickstart/portlet-definition/xkcd.portlet-definition.xml
+++ b/data/quickstart/portlet-definition/xkcd.portlet-definition.xml
@@ -31,6 +31,7 @@
         <ns2:portletName>news</ns2:portletName>
     </portlet-descriptor>
     <category>Entertainment</category>
+    <category>Quicklinks</category>
     <group>Everyone</group>
     <permissions>
         <permission system="UP_PORTLET_SUBSCRIBE" activity="BROWSE">

--- a/gradle.properties
+++ b/gradle.properties
@@ -23,8 +23,8 @@ weatherPortletVersion=1.1.7
 webProxyPortletVersion=2.3.1
 
 # Versions of WebJars included with resource-server
-contentCarouselVersion=1.7.4
-waffleMenuVersion=1.7.4
+contentCarouselVersion=1.8.0
+waffleMenuVersion=1.8.0
 
 portletApiDependency=org.apache.portals:portlet-api_2.1.0_spec:1.0
 servletApiDependency=javax.servlet:javax.servlet-api:3.0.1

--- a/gradle.properties
+++ b/gradle.properties
@@ -23,8 +23,8 @@ weatherPortletVersion=1.1.7
 webProxyPortletVersion=2.3.1
 
 # Versions of WebJars included with resource-server
-contentCarouselVersion=1.10.1
-waffleMenuVersion=1.10.1
+contentCarouselVersion=1.11.0
+waffleMenuVersion=1.11.0
 
 portletApiDependency=org.apache.portals:portlet-api_2.1.0_spec:1.0
 servletApiDependency=javax.servlet:javax.servlet-api:3.0.1

--- a/gradle.properties
+++ b/gradle.properties
@@ -23,8 +23,8 @@ weatherPortletVersion=1.1.7
 webProxyPortletVersion=2.3.1
 
 # Versions of WebJars included with resource-server
-contentCarouselVersion=1.11.0
-waffleMenuVersion=1.11.0
+contentCarouselVersion=1.11.1
+waffleMenuVersion=1.11.1
 
 portletApiDependency=org.apache.portals:portlet-api_2.1.0_spec:1.0
 servletApiDependency=javax.servlet:javax.servlet-api:3.0.1

--- a/gradle.properties
+++ b/gradle.properties
@@ -23,8 +23,8 @@ weatherPortletVersion=1.1.7
 webProxyPortletVersion=2.3.1
 
 # Versions of WebJars included with resource-server
-contentCarouselVersion=1.9.1
-waffleMenuVersion=1.9.1
+contentCarouselVersion=1.10.1
+waffleMenuVersion=1.10.1
 
 portletApiDependency=org.apache.portals:portlet-api_2.1.0_spec:1.0
 servletApiDependency=javax.servlet:javax.servlet-api:3.0.1

--- a/gradle.properties
+++ b/gradle.properties
@@ -23,8 +23,8 @@ weatherPortletVersion=1.1.7
 webProxyPortletVersion=2.3.1
 
 # Versions of WebJars included with resource-server
-contentCarouselVersion=1.11.1
-waffleMenuVersion=1.11.1
+contentCarouselVersion=1.13.4
+waffleMenuVersion=1.13.4
 
 portletApiDependency=org.apache.portals:portlet-api_2.1.0_spec:1.0
 servletApiDependency=javax.servlet:javax.servlet-api:3.0.1

--- a/gradle.properties
+++ b/gradle.properties
@@ -23,8 +23,8 @@ weatherPortletVersion=1.1.7
 webProxyPortletVersion=2.3.1
 
 # Versions of WebJars included with resource-server
-contentCarouselVersion=1.8.0
-waffleMenuVersion=1.8.0
+contentCarouselVersion=1.9.1
+waffleMenuVersion=1.9.1
 
 portletApiDependency=org.apache.portals:portlet-api_2.1.0_spec:1.0
 servletApiDependency=javax.servlet:javax.servlet-api:3.0.1


### PR DESCRIPTION
… the content-carousel and the waffle-menu (2 new Web Components from uPortal-web-components)

WIP:  Needs some collaboration.

@ChristianMurphy @cparaiso

<!--
Thank you for your pull request. Please review below requirements.

Bug fixes and new features should be reported on the issue tracker: https://issues.jasig.org/browse/UP/

Contributors guide: https://github.com/Jasig/uPortal/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

-   [x] the [individual contributor license agreement][] is signed
-   [x] commit message follows [commit guidelines][]
-   [ ] documentation is changed or added
-   [ ] [message properties][] have been updated with new phrases
-   [ ] view conforms with [WCAG 2.0 AA][]

##### Description of change
<!-- Provide a description of the change below this comment. -->

Bring the `content-carousel` and the `waffle-menu` into the Quickstart data set.

<!-- Reference Links -->

[individual contributor license agreement]: https://github.com/Jasig/uPortal/blob/master/.github/CONTRIBUTING.md#individual-contributor-license-agreement
[commit guidelines]: https://github.com/Jasig/uPortal/blob/master/.github/CONTRIBUTING.md#commit
[message properties]: https://github.com/Jasig/uPortal/tree/master/uportal-war/src/main/resources/properties/i18n
[WCAG 2.0 AA]: https://www.w3.org/WAI/WCAG20/quickref/?levels=aaa&technologies=smil%2Cpdf%2Cflash%2Csl
