### PR TITLE
Cleaning about PersonManager property

### DIFF
--- a/etc/portal/uPortal.properties
+++ b/etc/portal/uPortal.properties
@@ -69,11 +69,6 @@ org.apereo.portal.security.provider.cas.CasAssertionSecurityContextFactory.enabl
 #org.apereo.portal.security.provider.cas.CasAssertionSecurityContextFactory.credentialToken=ticket
 
 ##
-## Remote User (Shibboleth, etc.)
-##
-#org.apereo.portal.security.provider.RemoteUserSecurityContextFactory.enabled=false
-
-##
 ## LDAP
 ##
 #org.apereo.portal.security.provider.SimpleLdapSecurityContextFactory.enabled=false


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.

Bug fixes and new features should be reported on the issue tracker: https://issues.jasig.org/browse/UP/

Contributors guide: https://github.com/Jasig/uPortal/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

-   [x] the [individual contributor license agreement][] is signed
-   [x] commit message follows [commit guidelines][]
-   [ ] tests are included
-   [ ] documentation is changed or added
-   [ ] [message properties][] have been updated with new phrases
-   [ ] view conforms with [WCAG 2.0 AA][]

##### Description of change
<!-- Provide a description of the change below this comment. -->
Depends on https://github.com/Jasig/uPortal/pull/1318

Remove useless property as the RemoteUserPersonManager is enabled by default

<!-- Reference Links -->

[individual contributor license agreement]: https://github.com/Jasig/uPortal/blob/master/.github/CONTRIBUTING.md#individual-contributor-license-agreement
[commit guidelines]: https://github.com/Jasig/uPortal/blob/master/.github/CONTRIBUTING.md#commit
[message properties]: https://github.com/Jasig/uPortal/tree/master/uportal-war/src/main/resources/properties/i18n
[WCAG 2.0 AA]: https://www.w3.org/WAI/WCAG20/quickref/?levels=aaa&technologies=smil%2Cpdf%2Cflash%2Csl
