### PR TITLE
fix: custom elements must have a closing tag

### DIFF
--- a/data/quickstart/portlet-definition/waffle-menu.portlet-definition.xml
+++ b/data/quickstart/portlet-definition/waffle-menu.portlet-definition.xml
@@ -83,7 +83,8 @@
             <script src="/resource-server/webjars/uportal__waffle-menu/build/static/js/waffle-menu.js"></script>
             <waffle-menu
                     url="/uPortal/api/v4-3/dlm/portletRegistry.json?category=Quicklinks"
-                    style="font-size: 75%; position: relative; top: .25rem;" />
+                    style="font-size: 75%; position: relative; top: .25rem;">
+            </waffle-menu>
         ]]>
     </value>
 </portlet-preference>


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.

Bug fixes and new features should be reported on the issue tracker: https://issues.jasig.org/browse/UP/

Contributors guide: https://github.com/Jasig/uPortal/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

-   [x] the [individual contributor license agreement][] is signed
-   [x] commit message follows [commit guidelines][]

##### Description of change
<!-- Provide a description of the change below this comment. -->

Self closing custom tags are not part of the spec.

<!-- Reference Links -->

[individual contributor license agreement]: https://github.com/Jasig/uPortal/blob/master/.github/CONTRIBUTING.md#individual-contributor-license-agreement
[commit guidelines]: https://github.com/Jasig/uPortal/blob/master/.github/CONTRIBUTING.md#commit
[message properties]: https://github.com/Jasig/uPortal/tree/master/uportal-war/src/main/resources/properties/i18n
[WCAG 2.0 AA]: https://www.w3.org/WAI/WCAG20/quickref/?levels=aaa&technologies=smil%2Cpdf%2Cflash%2Csl
