### PR TITLE
fix: use production minified vue and component

### DIFF
--- a/data/quickstart/portlet-definition/favorites-carousel.portlet-definition.xml
+++ b/data/quickstart/portlet-definition/favorites-carousel.portlet-definition.xml
@@ -64,8 +64,8 @@
         <readOnly>false</readOnly>
         <value>
             <![CDATA[
-                <script src="/resource-server/webjars/vue/dist/vue.js"></script>
-                <script src="/resource-server/webjars/uportal__content-carousel/dist/content-carousel.js"></script>
+                <script src="/resource-server/webjars/vue/dist/vue.min.js"></script>
+                <script src="/resource-server/webjars/uportal__content-carousel/dist/content-carousel.min.js"></script>
                 <content-carousel
                         type="portlet"
                         source="/uPortal/api/v4-3/dlm/portletRegistry.json?favorite=true"


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.

Bug fixes and new features should be reported on the issue tracker: https://issues.jasig.org/browse/UP/

Contributors guide: https://github.com/Jasig/uPortal/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

-   [x] the [individual contributor license agreement][] is signed
-   [x] commit message follows [commit guidelines][]

##### Description of change
<!-- Provide a description of the change below this comment. -->

Non minified version of vue can cause IE to randomly hang while loading the page.

<!-- Reference Links -->

[individual contributor license agreement]: https://github.com/Jasig/uPortal/blob/master/.github/CONTRIBUTING.md#individual-contributor-license-agreement
[commit guidelines]: https://github.com/Jasig/uPortal/blob/master/.github/CONTRIBUTING.md#commit
[message properties]: https://github.com/Jasig/uPortal/tree/master/uportal-war/src/main/resources/properties/i18n
[WCAG 2.0 AA]: https://www.w3.org/WAI/WCAG20/quickref/?levels=aaa&technologies=smil%2Cpdf%2Cflash%2Csl
