### PR TITLE
feat: outdated browser informational screen

### DIFF
--- a/data/quickstart/fragment-layout/authenticated-lo.fragment-layout.xml
+++ b/data/quickstart/fragment-layout/authenticated-lo.fragment-layout.xml
@@ -38,6 +38,7 @@
             <channel fname="personalization-gallery" unremovable="false" hidden="false" immutable="false" ID="n42"/>
         </folder> -->
         <folder ID="s100" hidden="false" immutable="true" name="Eyebrow folder" type="eyebrow" unremovable="true">
+            <channel fname="outdated-browser" unremovable="false" hidden="false" immutable="false" ID="n105"/>
             <channel fname="waffle-menu" unremovable="false" hidden="false" immutable="false" ID="n110"/>
             <channel fname="notification-icon" unremovable="false" hidden="false" immutable="false" ID="n120"/>
             <channel fname="portal-greeting" unremovable="false" hidden="false" immutable="false" ID="n130"/>

--- a/data/quickstart/portlet-definition/outdated-browser-definition.xml
+++ b/data/quickstart/portlet-definition/outdated-browser-definition.xml
@@ -1,0 +1,113 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<!--
+
+    Licensed to Apereo under one or more contributor license
+    agreements. See the NOTICE file distributed with this work
+    for additional information regarding copyright ownership.
+    Apereo licenses this file to you under the Apache License,
+    Version 2.0 (the "License"); you may not use this file
+    except in compliance with the License.  You may obtain a
+    copy of the License at the following location:
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied.  See the License for the
+    specific language governing permissions and limitations
+    under the License.
+
+-->
+<portlet-definition xmlns="https://source.jasig.org/schemas/uportal/io/portlet-definition" xmlns:ns2="https://source.jasig.org/schemas/uportal" xmlns:ns3="https://source.jasig.org/schemas/uportal/io/stylesheet-descriptor" xmlns:ns4="https://source.jasig.org/schemas/uportal/io/permission-owner" xmlns:ns5="https://source.jasig.org/schemas/uportal/io/subscribed-fragment" xmlns:ns6="https://source.jasig.org/schemas/uportal/io/event-aggregation" xmlns:ns7="https://source.jasig.org/schemas/uportal/io/user" xmlns:ns8="https://source.jasig.org/schemas/uportal/io/portlet-type" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="4.0" xsi:schemaLocation="https://source.jasig.org/schemas/uportal/io/portlet-definition https://source.jasig.org/schemas/uportal/io/portlet-definition/portlet-definition-4.0.xsd">
+    <title>Outdated Browser</title>
+    <name>Outdated Browser</name>
+    <fname>outdated-browser</fname>
+    <desc>An informational notification when a user accesses the UI with an outdated browser</desc>
+    <type>Advanced CMS</type>
+    <timeout>5000</timeout>
+    <portlet-descriptor>
+        <ns2:webAppName>/SimpleContentPortlet</ns2:webAppName>
+        <ns2:portletName>cms</ns2:portletName>
+    </portlet-descriptor>
+    <group>Everyone</group>
+    <parameter>
+        <name>alternate</name>
+        <value>false</value>
+    </parameter>
+    <parameter>
+        <name>blockImpersonation</name>
+        <value>false</value>
+    </parameter>
+    <parameter>
+        <name>disableDynamicTitle</name>
+        <value>true</value>
+    </parameter>
+    <parameter>
+        <name>editable</name>
+        <value>false</value>
+    </parameter>
+    <parameter>
+        <name>hasAbout</name>
+        <value>false</value>
+    </parameter>
+    <parameter>
+        <name>hasHelp</name>
+        <value>false</value>
+    </parameter>
+    <parameter>
+        <name>hideFromMobile</name>
+        <value>false</value>
+    </parameter>
+    <parameter>
+        <name>highlight</name>
+        <value>false</value>
+    </parameter>
+    <parameter>
+        <name>iconUrl</name>
+        <value>/ResourceServingWebapp/rs/tango/0.8.90/32x32/status/dialog-warning.png</value>
+    </parameter>
+    <parameter>
+        <name>mobileIconUrl</name>
+        <value>/uPortal/media/skins/icons/mobile/bullhorn.png</value>
+    </parameter>
+    <parameter>
+        <name>showChrome</name>
+        <value>false</value>
+    </parameter>
+<portlet-preference>
+    <name>content</name>
+    <readOnly>false</readOnly>
+    <value>
+        <![CDATA[
+            <link rel="stylesheet" href="/resource-server/webjars/outdatedbrowser/outdatedbrowser/outdatedbrowser.min.css">
+            <script src="/resource-server/webjars/outdatedbrowser/outdatedbrowser/outdatedbrowser.min.js"></script>
+            <div id="outdated"></div>
+            <script>
+                function addLoadEvent(func) {
+                    var oldonload = window.onload;
+                    if (typeof window.onload != 'function') {
+                        window.onload = func;
+                    } else {
+                        window.onload = function() {
+                            if (oldonload) {
+                                oldonload();
+                            }
+                            func();
+                        }
+                    }
+                }
+                //call plugin function after DOM ready
+                addLoadEvent(function(){
+                    outdatedBrowser({
+                        bgColor: '#f25648',
+                        color: '#ffffff',
+                        lowerThan: 'transform',
+                        languagePath: '/resource-server/webjars/outdatedbrowser/lang/en.html'
+                    })
+                });
+            </script>
+        ]]>
+    </value>
+</portlet-preference>
+</portlet-definition>

--- a/gradle.properties
+++ b/gradle.properties
@@ -27,6 +27,7 @@ contentCarouselVersion=1.22.1
 escoContentMenuVersion=1.22.1
 waffleMenuVersion=1.22.1
 vueVersion=2.5.21
+outdatedbrowserVersion=1.1.5
 
 portletApiDependency=org.apache.portals:portlet-api_2.1.0_spec:1.0
 servletApiDependency=javax.servlet:javax.servlet-api:3.0.1

--- a/overlays/resource-server/build.gradle
+++ b/overlays/resource-server/build.gradle
@@ -15,6 +15,7 @@ dependencies {
     runtime "org.webjars.npm:uportal__esco-content-menu:${escoContentMenuVersion}@jar"
     runtime "org.webjars.npm:uportal__waffle-menu:${waffleMenuVersion}@jar"
     runtime "org.webjars.npm:vue:${vueVersion}@jar"
+    runtime "org.webjars.npm:outdatedbrowser:${outdatedbrowserVersion}@jar"
 }
 
 war {


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.

Bug fixes and new features should be reported on the issue tracker: https://issues.jasig.org/browse/UP/

Contributors guide: https://github.com/Jasig/uPortal/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

-   [x] the [individual contributor license agreement][] is signed
-   [x] commit message follows [commit guidelines][]

##### Description of change
<!-- Provide a description of the change below this comment. -->

when IE, older Chrome/Safari/Firefox connect to uPortal, uPortal will display information page suggesting the user upgrades to a evergreen browser.
built on http://outdatedbrowser.com/en

<!-- Reference Links -->

[individual contributor license agreement]: https://github.com/Jasig/uPortal/blob/master/.github/CONTRIBUTING.md#individual-contributor-license-agreement
[commit guidelines]: https://github.com/Jasig/uPortal/blob/master/.github/CONTRIBUTING.md#commit
[message properties]: https://github.com/Jasig/uPortal/tree/master/uportal-war/src/main/resources/properties/i18n
[WCAG 2.0 AA]: https://www.w3.org/WAI/WCAG20/quickref/?levels=aaa&technologies=smil%2Cpdf%2Cflash%2Csl
