### PR TITLE
refactor: defer loading of web components, unblocking first render

### DIFF
--- a/data/quickstart/portlet-definition/admin-dashboard.portlet-definition.xml
+++ b/data/quickstart/portlet-definition/admin-dashboard.portlet-definition.xml
@@ -81,7 +81,7 @@
     <value>
         <![CDATA[
             <script src="/resource-server/webjars/vue/dist/vue.min.js"></script>
-            <script type="text/javascript" src="/resource-server/webjars/uportal__esco-content-menu/dist/esco.min.js"></script>
+            <script type="text/javascript" src="/resource-server/webjars/uportal__esco-content-menu/dist/esco.min.js" defer></script>
 
             <esco-content-grid
               portlet-api-url="/uPortal/api/v4-3/dlm/portletRegistry.json?category=Administration"

--- a/data/quickstart/portlet-definition/favorites-carousel.portlet-definition.xml
+++ b/data/quickstart/portlet-definition/favorites-carousel.portlet-definition.xml
@@ -65,7 +65,7 @@
         <value>
             <![CDATA[
                 <script src="/resource-server/webjars/vue/dist/vue.min.js"></script>
-                <script src="/resource-server/webjars/uportal__content-carousel/dist/content-carousel.min.js"></script>
+                <script src="/resource-server/webjars/uportal__content-carousel/dist/content-carousel.min.js" defer></script>
                 <content-carousel
                         type="portlet"
                         source="/uPortal/api/v4-3/dlm/portletRegistry.json?favorite=true"

--- a/data/quickstart/portlet-definition/notification-icon.portlet-definition.xml
+++ b/data/quickstart/portlet-definition/notification-icon.portlet-definition.xml
@@ -81,7 +81,7 @@
         <value>
             <![CDATA[
                 <script src="/resource-server/webjars/vue/dist/vue.min.js"></script>
-                <script type="text/javascript" src="/NotificationPortlet/scripts/notification-icon.min.js"></script>
+                <script type="text/javascript" src="/NotificationPortlet/scripts/notification-icon.min.js" defer></script>
                 <notification-icon style="position: relative; top: -0.5rem;"></notification-icon>
             ]]>
         </value>

--- a/data/quickstart/portlet-definition/waffle-menu.portlet-definition.xml
+++ b/data/quickstart/portlet-definition/waffle-menu.portlet-definition.xml
@@ -81,7 +81,7 @@
     <value>
         <![CDATA[
             <script src="/resource-server/webjars/vue/dist/vue.min.js"></script>
-            <script src="/resource-server/webjars/uportal__waffle-menu/dist/waffle-menu.min.js"></script>
+            <script src="/resource-server/webjars/uportal__waffle-menu/dist/waffle-menu.min.js" defer></script>
             <waffle-menu
                     url="/uPortal/api/v4-3/dlm/portletRegistry.json?category=Quicklinks"
                     style="position: relative; top: 0.25rem;">


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.

Bug fixes and new features should be reported on the issue tracker: https://issues.jasig.org/browse/UP/

Contributors guide: https://github.com/Jasig/uPortal/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

-   [x] the [individual contributor license agreement][] is signed
-   [x] commit message follows [commit guidelines][]

##### Description of change
<!-- Provide a description of the change below this comment. -->

first paint/render is currently blocked by web component loading, this
defers loading of components so page can render, then fill in web
components a moment later in a second page paint.

This improves perceived load time of uPortal.

<!-- Reference Links -->

[individual contributor license agreement]: https://github.com/Jasig/uPortal/blob/master/.github/CONTRIBUTING.md#individual-contributor-license-agreement
[commit guidelines]: https://github.com/Jasig/uPortal/blob/master/.github/CONTRIBUTING.md#commit
[message properties]: https://github.com/Jasig/uPortal/tree/master/uportal-war/src/main/resources/properties/i18n
[WCAG 2.0 AA]: https://www.w3.org/WAI/WCAG20/quickref/?levels=aaa&technologies=smil%2Cpdf%2Cflash%2Csl
