### PR TITLE
feat: enable compression in Tomcat by default

### DIFF
--- a/etc/tomcat/conf/server.xml
+++ b/etc/tomcat/conf/server.xml
@@ -69,7 +69,12 @@
     <Connector port="8080" protocol="HTTP/1.1"
                connectionTimeout="20000"
                redirectPort="8443"
-               maxThreads="1200" /><!-- Model: 500 users, 1 page / 15 sec, 25 HTTP req / page, 20% buffer -->
+               maxThreads="1200"
+               compression="on" 
+               compressionMinSize="1024" 
+               compressableMimeType="text/html,text/xml,text/plain,text/css,text/javascript,application/javascript,application/json"
+    />
+    <!-- Model: 500 users, 1 page / 15 sec, 25 HTTP req / page, 20% buffer -->
     <!-- A "Connector" using the shared thread pool-->
     <!--
     <Connector executor="tomcatThreadPool"


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.

Bug fixes and new features should be reported on the issue tracker: https://issues.jasig.org/browse/UP/

Contributors guide: https://github.com/Jasig/uPortal/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

-   [x] the [individual contributor license agreement][] is signed
-   [x] commit message follows [commit guidelines][]

##### Description of change
<!-- Provide a description of the change below this comment. -->

Having compression for JavaScript, JSON, and HTML significantly improves load times in worsened network conditions.
This can be disabled if a server fronting uPortal also is also compressing content.

<!-- Reference Links -->

[individual contributor license agreement]: https://github.com/Jasig/uPortal/blob/master/.github/CONTRIBUTING.md#individual-contributor-license-agreement
[commit guidelines]: https://github.com/Jasig/uPortal/blob/master/.github/CONTRIBUTING.md#commit
[message properties]: https://github.com/Jasig/uPortal/tree/master/uportal-war/src/main/resources/properties/i18n
[WCAG 2.0 AA]: https://www.w3.org/WAI/WCAG20/quickref/?levels=aaa&technologies=smil%2Cpdf%2Cflash%2Csl
