### PR TITLE
chore(dependencies): update notificationPortletVersion to 4.5.3 and notificationWebComponentsVersion to 1.0.2

### DIFF
--- a/data/quickstart/fragment-layout/academics-lo.fragment-layout.xml
+++ b/data/quickstart/fragment-layout/academics-lo.fragment-layout.xml
@@ -19,11 +19,11 @@
     under the License.
 
 -->
-<layout xmlns:dlm="http://www.uportal.org/layout/dlm" script="classpath://org/jasig/portal/io/import-layout_v3-2.crn" 
+<layout xmlns:dlm="http://www.uportal.org/layout/dlm" script="classpath://org/jasig/portal/io/import-layout_v3-2.crn"
   username="academics-lo" >
   <folder ID="s1" hidden="false" immutable="false" name="Root folder" type="root" unremovable="true">
     <!--
-     | Hidden folders do not propagate to regular users, and fragment owner 
+     | Hidden folders do not propagate to regular users, and fragment owner
      | accounts don't receive (other) fragments at all;  Fragment owners must
      | have their own copies of the minimal portlets required to view and manage
      | their own layouts.
@@ -49,7 +49,6 @@
           <name>width</name>
           <value>50%</value>
         </structure-attribute>
-        <channel fname="notification" unremovable="false" hidden="false" immutable="false" ID="n12"/>
         <channel fname="google-docs" unremovable="false" hidden="false" immutable="false" ID="n13"/>
       </folder>
     </folder>

--- a/data/quickstart/fragment-layout/staff-lo.fragment-layout.xml
+++ b/data/quickstart/fragment-layout/staff-lo.fragment-layout.xml
@@ -19,11 +19,11 @@
     under the License.
 
 -->
-<layout xmlns:dlm="http://www.uportal.org/layout/dlm" script="classpath://org/jasig/portal/io/import-layout_v3-2.crn" 
+<layout xmlns:dlm="http://www.uportal.org/layout/dlm" script="classpath://org/jasig/portal/io/import-layout_v3-2.crn"
     username="staff-lo" >
     <folder ID="s1" hidden="false" immutable="false" name="Root folder" type="root" unremovable="true">
         <!--
-         | Hidden folders do not propagate to regular users, and fragment owner 
+         | Hidden folders do not propagate to regular users, and fragment owner
          | accounts don't receive (other) fragments at all;  Fragment owners must
          | have their own copies of the minimal portlets required to view and manage
          | their own layouts.
@@ -52,7 +52,6 @@
                     <name>width</name>
                     <value>40%</value>
                 </structure-attribute>
-                <channel fname="notification" unremovable="false" hidden="false" immutable="false" ID="n11"/>
                 <channel fname="whos-online" unremovable="false" hidden="false" immutable="false" ID="n12"/>
             </folder>
         </folder>

--- a/data/quickstart/portlet-definition/notification-banner.portlet-definition.xml
+++ b/data/quickstart/portlet-definition/notification-banner.portlet-definition.xml
@@ -20,10 +20,10 @@
 
 -->
 <portlet-definition xmlns="https://source.jasig.org/schemas/uportal/io/portlet-definition" xmlns:ns2="https://source.jasig.org/schemas/uportal" xmlns:ns3="https://source.jasig.org/schemas/uportal/io/stylesheet-descriptor" xmlns:ns4="https://source.jasig.org/schemas/uportal/io/permission-owner" xmlns:ns5="https://source.jasig.org/schemas/uportal/io/subscribed-fragment" xmlns:ns6="https://source.jasig.org/schemas/uportal/io/event-aggregation" xmlns:ns7="https://source.jasig.org/schemas/uportal/io/user" xmlns:ns8="https://source.jasig.org/schemas/uportal/io/portlet-type" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="4.0" xsi:schemaLocation="https://source.jasig.org/schemas/uportal/io/portlet-definition https://source.jasig.org/schemas/uportal/io/portlet-definition/portlet-definition-4.0.xsd">
-    <title>Notification Icon</title>
-    <name>Notification Icon</name>
-    <fname>notification-icon</fname>
-    <desc>Icon-based launcher for the Apereo Notification portlet designed for the eyebrow region of the page</desc>
+    <title>Notification Banner</title>
+    <name>Notification Banner</name>
+    <fname>notification-banner</fname>
+    <desc>View important notifications as banners</desc>
     <type>Advanced CMS</type>
     <timeout>5000</timeout>
     <portlet-descriptor>
@@ -38,6 +38,10 @@
     <parameter>
         <name>blockImpersonation</name>
         <value>false</value>
+    </parameter>
+    <parameter>
+        <name>chromeStyle</name>
+        <value>no-chrome</value>
     </parameter>
     <parameter>
         <name>disableDynamicTitle</name>
@@ -81,11 +85,9 @@
         <value>
             <![CDATA[
                 <script src="/resource-server/webjars/vue/dist/vue.min.js"></script>
-                <script src="/resource-server/webjars/uportal__notification-icon/dist/notification-icon.min.js"></script>
-                <notification-icon
-                    see-all-notifications-url="/uPortal/p/notification-list"
-                    navigation-strategy="list"
-                    style="position: relative; top: -0.5rem;"></notification-icon>
+                <script src="/resource-server/webjars/uportal__notification-banner/dist/notification-banner.min.js"></script>
+                <notification-banner notification-api-url="/NotificationPortlet/api/v2/notifications?maxPriority=2">
+                </notification-banner>
             ]]>
         </value>
     </portlet-preference>

--- a/data/quickstart/portlet-definition/notification-banner.portlet-definition.xml
+++ b/data/quickstart/portlet-definition/notification-banner.portlet-definition.xml
@@ -85,7 +85,7 @@
         <value>
             <![CDATA[
                 <script src="/resource-server/webjars/vue/dist/vue.min.js"></script>
-                <script src="/resource-server/webjars/uportal__notification-banner/dist/notification-banner.min.js"></script>
+                <script src="/resource-server/webjars/uportal__notification-banner/dist/notification-banner.min.js" defer></script>
                 <notification-banner notification-api-url="/NotificationPortlet/api/v2/notifications?maxPriority=2">
                 </notification-banner>
             ]]>

--- a/data/quickstart/portlet-definition/notification-icon.portlet-definition.xml
+++ b/data/quickstart/portlet-definition/notification-icon.portlet-definition.xml
@@ -81,7 +81,7 @@
         <value>
             <![CDATA[
                 <script src="/resource-server/webjars/vue/dist/vue.min.js"></script>
-                <script src="/resource-server/webjars/uportal__notification-icon/dist/notification-icon.min.js"></script>
+                <script src="/resource-server/webjars/uportal__notification-icon/dist/notification-icon.min.js" defer></script>
                 <notification-icon
                     see-all-notifications-url="/uPortal/p/notification-list"
                     navigation-strategy="list"

--- a/data/quickstart/portlet-definition/notification-list.portlet-definition.xml
+++ b/data/quickstart/portlet-definition/notification-list.portlet-definition.xml
@@ -85,7 +85,7 @@
         <value>
             <![CDATA[
                 <script src="/resource-server/webjars/vue/dist/vue.min.js"></script>
-                <script src="/resource-server/webjars/uportal__notification-list/dist/notification-list.min.js"></script>
+                <script src="/resource-server/webjars/uportal__notification-list/dist/notification-list.min.js" defer></script>
                 <notification-list notification-api-url="/NotificationPortlet/api/v2/notifications?maxPriority=2" color-map="{
                         &quot;Parking&quot;: &quot;#6649bb&quot;,
                         &quot;Library&quot;: &quot;#487df9&quot;,

--- a/data/quickstart/portlet-definition/notification-list.portlet-definition.xml
+++ b/data/quickstart/portlet-definition/notification-list.portlet-definition.xml
@@ -20,23 +20,17 @@
 
 -->
 <portlet-definition xmlns="https://source.jasig.org/schemas/uportal/io/portlet-definition" xmlns:ns2="https://source.jasig.org/schemas/uportal" xmlns:ns3="https://source.jasig.org/schemas/uportal/io/stylesheet-descriptor" xmlns:ns4="https://source.jasig.org/schemas/uportal/io/permission-owner" xmlns:ns5="https://source.jasig.org/schemas/uportal/io/subscribed-fragment" xmlns:ns6="https://source.jasig.org/schemas/uportal/io/event-aggregation" xmlns:ns7="https://source.jasig.org/schemas/uportal/io/user" xmlns:ns8="https://source.jasig.org/schemas/uportal/io/portlet-type" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="4.0" xsi:schemaLocation="https://source.jasig.org/schemas/uportal/io/portlet-definition https://source.jasig.org/schemas/uportal/io/portlet-definition/portlet-definition-4.0.xsd">
-    <title>Notification Portlet</title>
-    <name>Notification Portlet</name>
-    <fname>notification</fname>
-    <desc>Apereo Notification Portlet</desc>
-    <type>Portlet</type>
-    <timeout>20000</timeout>
+    <title>Notification List</title>
+    <name>Notification List</name>
+    <fname>notification-list</fname>
+    <desc>Primary, comprehensive way to view notifications</desc>
+    <type>Advanced CMS</type>
+    <timeout>5000</timeout>
     <portlet-descriptor>
-        <ns2:webAppName>/NotificationPortlet</ns2:webAppName>
-        <ns2:portletName>Notifications</ns2:portletName>
+        <ns2:webAppName>/SimpleContentPortlet</ns2:webAppName>
+        <ns2:portletName>cms</ns2:portletName>
     </portlet-descriptor>
-    <category>Information</category>
-    <group>Everyone</group>
-    <permissions>
-        <permission system="UP_PORTLET_SUBSCRIBE" activity="BROWSE">
-            <group>Everyone</group>
-        </permission>
-    </permissions>
+    <group>Authenticated Users</group>
     <parameter>
         <name>alternate</name>
         <value>false</value>
@@ -44,6 +38,10 @@
     <parameter>
         <name>blockImpersonation</name>
         <value>false</value>
+    </parameter>
+    <parameter>
+        <name>chromeStyle</name>
+        <value>no-chrome</value>
     </parameter>
     <parameter>
         <name>disableDynamicTitle</name>
@@ -82,9 +80,19 @@
         <value>true</value>
     </parameter>
     <portlet-preference>
-        <name>DemoNotificationService.locations</name>
+        <name>content</name>
         <readOnly>false</readOnly>
-        <value>demo/demoNotificationResponse2.json</value>
-        <value>demo/demoNotificationResponse.json</value>
+        <value>
+            <![CDATA[
+                <script src="/resource-server/webjars/vue/dist/vue.min.js"></script>
+                <script src="/resource-server/webjars/uportal__notification-list/dist/notification-list.min.js"></script>
+                <notification-list notification-api-url="/NotificationPortlet/api/v2/notifications?maxPriority=2" color-map="{
+                        &quot;Parking&quot;: &quot;#6649bb&quot;,
+                        &quot;Library&quot;: &quot;#487df9&quot;,
+                        &quot;Assignments&quot;: &quot;#c85a89&quot;
+                    }">
+                </notification-list>
+            ]]>
+        </value>
     </portlet-preference>
 </portlet-definition>

--- a/data/quickstart/portlet-definition/notification-modal.portlet-definition.xml
+++ b/data/quickstart/portlet-definition/notification-modal.portlet-definition.xml
@@ -85,7 +85,7 @@
         <value>
             <![CDATA[
                 <script src="/resource-server/webjars/vue/dist/vue.min.js"></script>
-                <script src="/resource-server/webjars/uportal__notification-modal/dist/notification-modal.min.js"></script>
+                <script src="/resource-server/webjars/uportal__notification-modal/dist/notification-modal.min.js" defer></script>
                 <notification-modal notification-api-url="/NotificationPortlet/api/v2/notifications?minPriority=3">
                 </notification-modal>
             ]]>

--- a/data/quickstart/portlet-definition/notification-modal.portlet-definition.xml
+++ b/data/quickstart/portlet-definition/notification-modal.portlet-definition.xml
@@ -20,10 +20,10 @@
 
 -->
 <portlet-definition xmlns="https://source.jasig.org/schemas/uportal/io/portlet-definition" xmlns:ns2="https://source.jasig.org/schemas/uportal" xmlns:ns3="https://source.jasig.org/schemas/uportal/io/stylesheet-descriptor" xmlns:ns4="https://source.jasig.org/schemas/uportal/io/permission-owner" xmlns:ns5="https://source.jasig.org/schemas/uportal/io/subscribed-fragment" xmlns:ns6="https://source.jasig.org/schemas/uportal/io/event-aggregation" xmlns:ns7="https://source.jasig.org/schemas/uportal/io/user" xmlns:ns8="https://source.jasig.org/schemas/uportal/io/portlet-type" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="4.0" xsi:schemaLocation="https://source.jasig.org/schemas/uportal/io/portlet-definition https://source.jasig.org/schemas/uportal/io/portlet-definition/portlet-definition-4.0.xsd">
-    <title>Notification Icon</title>
-    <name>Notification Icon</name>
-    <fname>notification-icon</fname>
-    <desc>Icon-based launcher for the Apereo Notification portlet designed for the eyebrow region of the page</desc>
+    <title>Notification Modal</title>
+    <name>Notification Modal</name>
+    <fname>notification-modal</fname>
+    <desc>View important notifications as modal dialogs</desc>
     <type>Advanced CMS</type>
     <timeout>5000</timeout>
     <portlet-descriptor>
@@ -38,6 +38,10 @@
     <parameter>
         <name>blockImpersonation</name>
         <value>false</value>
+    </parameter>
+    <parameter>
+        <name>chromeStyle</name>
+        <value>no-chrome</value>
     </parameter>
     <parameter>
         <name>disableDynamicTitle</name>
@@ -81,11 +85,9 @@
         <value>
             <![CDATA[
                 <script src="/resource-server/webjars/vue/dist/vue.min.js"></script>
-                <script src="/resource-server/webjars/uportal__notification-icon/dist/notification-icon.min.js"></script>
-                <notification-icon
-                    see-all-notifications-url="/uPortal/p/notification-list"
-                    navigation-strategy="list"
-                    style="position: relative; top: -0.5rem;"></notification-icon>
+                <script src="/resource-server/webjars/uportal__notification-modal/dist/notification-modal.min.js"></script>
+                <notification-modal notification-api-url="/NotificationPortlet/api/v2/notifications?minPriority=3">
+                </notification-modal>
             ]]>
         </value>
     </portlet-preference>

--- a/gradle.properties
+++ b/gradle.properties
@@ -15,7 +15,7 @@ jasigWidgetPortletVersion=2.3.0
 resourceServerVersion=1.0.48
 resourceServer13Version=1.3.1
 newsReaderPortletVersion=5.0.3
-notificationPortletVersion=4.5.2
+notificationPortletVersion=4.5.3
 sakaiConnectorPortletVersion=1.5.2
 simpleContentPortletVersion=3.1.2
 uPortalVersion=5.5.1
@@ -23,10 +23,9 @@ weatherPortletVersion=1.1.7
 webProxyPortletVersion=2.3.2
 
 # Versions of WebJars included with resource-server
-contentCarouselVersion=1.24.0
-escoContentMenuVersion=1.24.0
-waffleMenuVersion=1.24.0
 vueVersion=2.6.10
+uPortalWebComponentsVersion=1.28.0
+notificationWebComponentsVersion=1.0.2
 
 portletApiDependency=org.apache.portals:portlet-api_2.1.0_spec:1.0
 servletApiDependency=javax.servlet:javax.servlet-api:3.0.1

--- a/overlays/resource-server/build.gradle
+++ b/overlays/resource-server/build.gradle
@@ -10,11 +10,20 @@
 dependencies {
     runtime "org.jasig.resourceserver:resource-server-webapp:${resourceServer13Version}@war"
 
-    // Webjars included with resource-server
-    runtime "org.webjars.npm:uportal__content-carousel:${contentCarouselVersion}@jar"
-    runtime "org.webjars.npm:uportal__esco-content-menu:${escoContentMenuVersion}@jar"
-    runtime "org.webjars.npm:uportal__waffle-menu:${waffleMenuVersion}@jar"
     runtime "org.webjars.npm:vue:${vueVersion}@jar"
+
+    // uPortal Web Components Webjars
+    runtime "org.webjars.npm:uportal__api-template-vue:${uPortalWebComponentsVersion}@jar"
+    runtime "org.webjars.npm:uportal__content-carousel:${uPortalWebComponentsVersion}@jar"
+    runtime "org.webjars.npm:uportal__esco-content-menu:${uPortalWebComponentsVersion}@jar"
+    runtime "org.webjars.npm:uportal__waffle-menu:${uPortalWebComponentsVersion}@jar"
+
+    // Notification Webjars
+    runtime "org.webjars.npm:uportal__notification-banner:${notificationWebComponentsVersion}@jar"
+    runtime "org.webjars.npm:uportal__notification-icon:${notificationWebComponentsVersion}@jar"
+    runtime "org.webjars.npm:uportal__notification-list:${notificationWebComponentsVersion}@jar"
+    runtime "org.webjars.npm:uportal__notification-modal:${notificationWebComponentsVersion}@jar"
+
 }
 
 war {


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.

Bug fixes and new features should be reported on the issue tracker: https://issues.jasig.org/browse/UP/

Contributors guide: https://github.com/Jasig/uPortal/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

-   [x] the [individual contributor license agreement][] is signed
-   [x] commit message follows [commit guidelines][]


##### Description of change
<!-- Provide a description of the change below this comment. -->

This pull request updates uPortal-start to Notification widgets released from [notification-web-components](https://github.com/uPortal-contrib/notification-web-components), rather than included as a part of the NotificationPortlet project.

<!-- Reference Links -->

[individual contributor license agreement]: https://github.com/Jasig/uPortal/blob/master/.github/CONTRIBUTING.md#individual-contributor-license-agreement
[commit guidelines]: https://github.com/Jasig/uPortal/blob/master/.github/CONTRIBUTING.md#commit
[message properties]: https://github.com/Jasig/uPortal/tree/master/uportal-war/src/main/resources/properties/i18n
[WCAG 2.0 AA]: https://www.w3.org/WAI/WCAG20/quickref/?levels=aaa&technologies=smil%2Cpdf%2Cflash%2Csl
