### PR TITLE
refactor: use health-check endpoint for Docker HEALTHCHECK

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -14,6 +14,6 @@ EXPOSE 8080
 # Execute a container based on this image by starting Tomcat in the foreground
 ENTRYPOINT ["tomcat/bin/catalina.sh", "run"]
 
-# The container is healthy if Tomcat can serve the error page (does not redirect) within 3 seconds
+# The container is healthy if Tomcat can serve the health check page within 3 seconds
 HEALTHCHECK --start-period=1m --interval=1m --timeout=3s \
     CMD wget --quiet --tries=1 --spider http://localhost:8080/uPortal/health-check || exit 1

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -16,4 +16,4 @@ ENTRYPOINT ["tomcat/bin/catalina.sh", "run"]
 
 # The container is healthy if Tomcat can serve the error page (does not redirect) within 3 seconds
 HEALTHCHECK --start-period=1m --interval=1m --timeout=3s \
-    CMD wget --quiet --tries=1 --spider http://localhost:8080/uPortal/500.html || exit 1
+    CMD wget --quiet --tries=1 --spider http://localhost:8080/uPortal/health-check || exit 1


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.

Bug fixes and new features should be reported on the issue tracker: https://issues.jasig.org/browse/UP/

Contributors guide: https://github.com/Jasig/uPortal/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

-   [x] the [individual contributor license agreement][] is signed
-   [x] commit message follows [commit guidelines][]
-   [x] tests are included

##### Description of change
<!-- Provide a description of the change below this comment. -->

Leverages the health check endpoint added in https://github.com/Jasig/uPortal/pull/1333

/cc @laurenra7

<!-- Reference Links -->

[individual contributor license agreement]: https://github.com/Jasig/uPortal/blob/master/.github/CONTRIBUTING.md#individual-contributor-license-agreement
[commit guidelines]: https://github.com/Jasig/uPortal/blob/master/.github/CONTRIBUTING.md#commit
[message properties]: https://github.com/Jasig/uPortal/tree/master/uportal-war/src/main/resources/properties/i18n
[WCAG 2.0 AA]: https://www.w3.org/WAI/WCAG20/quickref/?levels=aaa&technologies=smil%2Cpdf%2Cflash%2Csl
