### PR TITLE
docs(data): How to lock down non-admin layouts

### DIFF
--- a/docs/en/data/index.md
+++ b/docs/en/data/index.md
@@ -3,4 +3,5 @@
 This section of the documentation covers details of the data files
 used to configure uPortal.
 
+* [Lock Down User Layouts](lockdown-layouts.md)
 * [Session Timeout by Group](timeout.md)

--- a/docs/en/data/lockdown-layouts.md
+++ b/docs/en/data/lockdown-layouts.md
@@ -16,7 +16,7 @@ data/base/permission_set/Authenticated_Users__CUSTOMIZE__UP_SYSTEM.permission-se
 ````
 
 And should be copied to your permission_set data directory, changing target
-permission-type to DENY.
+`permission-type` to `DENY`.
 
 ```xml
 <permission-set script="classpath://org/jasig/portal/io/import-permission_set_v3-1.crn">

--- a/docs/en/data/lockdown-layouts.md
+++ b/docs/en/data/lockdown-layouts.md
@@ -1,0 +1,47 @@
+# Lock Down User Layouts
+
+It is now common practice to lock down user layouts such that non-admin users cannot
+modify what is on the page. This is especially so with new layouts where grids with
+filters and/or "Favorite" carousels are prominent.
+
+This is accomplished by denying `CUSTOMIZE` and `ADD_TAB` permissions in `UP_SYSTEM`.
+There are already default versions of files that `GRANT` these permissions in the
+`base` data set.
+
+The originals are:
+
+````bash
+data/base/permission_set/Authenticated_Users__ADD_TAB__UP_SYSTEM.permission-set.xml
+data/base/permission_set/Authenticated_Users__CUSTOMIZE__UP_SYSTEM.permission-set.xml
+````
+
+And should be copied to your permission_set data directory, changing target
+permission-type to DENY.
+
+```xml
+<permission-set script="classpath://org/jasig/portal/io/import-permission_set_v3-1.crn">
+  <owner>UP_SYSTEM</owner>
+  <principal-type>org.apereo.portal.groups.IEntityGroup</principal-type>
+  <principal>
+    <group>Authenticated Users</group>
+  </principal>
+  <activity>ADD_TAB</activity>
+  <target permission-type="DENY">
+    <literal>ALL</literal>
+  </target>
+</permission-set>
+```
+
+```xml
+<permission-set script="classpath://org/jasig/portal/io/import-permission_set_v3-1.crn">
+  <owner>UP_SYSTEM</owner>
+  <principal-type>org.apereo.portal.groups.IEntityGroup</principal-type>
+  <principal>
+    <group>Authenticated Users</group>
+  </principal>
+  <activity>CUSTOMIZE</activity>
+  <target permission-type="DENY">
+    <literal>ALL</literal>
+  </target>
+</permission-set>
+```


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.

Bug fixes and new features should be reported on the issue tracker: https://issues.jasig.org/browse/UP/

Contributors guide: https://github.com/Jasig/uPortal/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

-   [X] the [individual contributor license agreement][] is signed
-   [X] commit message follows [commit guidelines][]
-   [X] documentation is changed or added

##### Description of change
<!-- Provide a description of the change below this comment. -->
Describe how to lock down non-admin user layouts.

<!-- Reference Links -->

[individual contributor license agreement]: https://github.com/Jasig/uPortal/blob/master/.github/CONTRIBUTING.md#individual-contributor-license-agreement
[commit guidelines]: https://github.com/Jasig/uPortal/blob/master/.github/CONTRIBUTING.md#commit
[message properties]: https://github.com/Jasig/uPortal/tree/master/uportal-war/src/main/resources/properties/i18n
[WCAG 2.0 AA]: https://www.w3.org/WAI/WCAG20/quickref/?levels=aaa&technologies=smil%2Cpdf%2Cflash%2Csl
