### PR TITLE
GH-365. Use stopStartThreads=0

### DIFF
--- a/etc/tomcat/conf/server.xml
+++ b/etc/tomcat/conf/server.xml
@@ -153,7 +153,7 @@
 
       <Host name="localhost"  appBase="webapps"
             unpackWARs="true" autoDeploy="true"
-            startStopThreads="4">
+            startStopThreads="0">
 
         <!-- SingleSignOn valve, share authentication between web applications
              Documentation at: /docs/config/valve.html -->


### PR DESCRIPTION
-   [x] the [individual contributor license agreement][] is signed
-   [x] commit message follows [commit guidelines][]

For issue https://github.com/Jasig/uPortal-start/issues/365
Set startStopThreads=0 for improved tomcat startup performance on a larger variety of systems.