### PR TITLE
fix: defaulted CAS encodeServiceUrl to false for embedded CAS server

### DIFF
--- a/etc/portal/uPortal.properties
+++ b/etc/portal/uPortal.properties
@@ -68,6 +68,13 @@
 org.apereo.portal.security.provider.cas.CasAssertionSecurityContextFactory.enabled=true
 #org.apereo.portal.security.provider.cas.CasAssertionSecurityContextFactory.credentialToken=ticket
 
+## Some CAS servers, like the CAS server bundled with uPortal-start can not handle encoded service URLs.
+## By default, the following value is set to true
+## See https://groups.google.com/a/apereo.org/d/msg/uportal-user/44Uw1YP8_Mg/hLaTlEVZFAAJ
+## for the discussion regarding this property
+#
+cas.ticketValidationFilter.encodeServiceUrl=false
+
 ##
 ## LDAP
 ##

--- a/gradle.properties
+++ b/gradle.properties
@@ -18,7 +18,7 @@ newsReaderPortletVersion=5.0.3
 notificationPortletVersion=4.5.3
 sakaiConnectorPortletVersion=1.5.2
 simpleContentPortletVersion=3.1.2
-uPortalVersion=5.7.1
+uPortalVersion=5.8.0
 weatherPortletVersion=1.1.7
 webProxyPortletVersion=2.3.2
 


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.

Bug fixes and new features should be reported on the issue tracker: https://issues.jasig.org/browse/UP/

Contributors guide: https://github.com/Jasig/uPortal/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

-   [x] the [individual contributor license agreement][] is signed
-   [x] commit message follows [commit guidelines][]

##### Description of change
Defaulting CAS `encodeServiceUrl` to false for embedded CAS server. This is a follow-up to #372 

<!-- Reference Links -->

[individual contributor license agreement]: https://github.com/Jasig/uPortal/blob/master/.github/CONTRIBUTING.md#individual-contributor-license-agreement
[commit guidelines]: https://github.com/Jasig/uPortal/blob/master/.github/CONTRIBUTING.md#commit
[message properties]: https://github.com/Jasig/uPortal/tree/master/uportal-war/src/main/resources/properties/i18n
[WCAG 2.0 AA]: https://www.w3.org/WAI/WCAG20/quickref/?levels=aaa&technologies=smil%2Cpdf%2Cflash%2Csl
