### PR TITLE
fix(NotificationPortlet): corrected logger configuration

### DIFF
--- a/overlays/NotificationPortlet/src/main/resources/logback.xml
+++ b/overlays/NotificationPortlet/src/main/resources/logback.xml
@@ -80,7 +80,7 @@
   </appender>
 
   <!-- 
-   | Setup default log level to the build-defined value
+   | Setup default log level to INFO
    +-->
   <root level="INFO">
     <appender-ref ref="LOG" />
@@ -89,8 +89,8 @@
   <!-- 
    | Turn up logging for portlet specific package
    +-->
-    <!--
-  <logger name="org.jasig.portlet.notification" additivity="false" level="DEBUG">
+  <!--
+  <logger name="org.jasig.portlet.notice" additivity="false" level="DEBUG">
     <appender-ref ref="LOG" />
   </logger>
   -->


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.

Bug fixes and new features should be reported on the issue tracker: https://issues.jasig.org/browse/UP/

Contributors guide: https://github.com/Jasig/uPortal/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

-   [x] the [individual contributor license agreement][] is signed
-   [x] commit message follows [commit guidelines][]

##### Description of change
<!-- Provide a description of the change below this comment. -->
Corrected logger configuration for the NotificationPortlet overlay from `org.jasig.portlet.notification` to `org.jasig.portlet.notice`. The package name is correct in jasig/NotificationPortlet, but is incorrect in uPortal-start.

<!-- Reference Links -->

[individual contributor license agreement]: https://github.com/Jasig/uPortal/blob/master/.github/CONTRIBUTING.md#individual-contributor-license-agreement
[commit guidelines]: https://github.com/Jasig/uPortal/blob/master/.github/CONTRIBUTING.md#commit
[message properties]: https://github.com/Jasig/uPortal/tree/master/uportal-war/src/main/resources/properties/i18n
[WCAG 2.0 AA]: https://www.w3.org/WAI/WCAG20/quickref/?levels=aaa&technologies=smil%2Cpdf%2Cflash%2Csl
