### PR TITLE
fix: restore newsreader import feature

### DIFF
--- a/overlays/NewsReaderPortlet/build.gradle
+++ b/overlays/NewsReaderPortlet/build.gradle
@@ -100,3 +100,57 @@ dataInit {
         }
     }
 }
+
+dataImport {
+    doLast {
+        String dir = System.getProperty('dir') ?: "${buildDir}/export"
+        String dirEscaped = PortalShellInvoker.createGroovySafePath(dir)
+        println "Export directory: ${dirEscaped}"
+
+        File serverBase = rootProject.file(rootProject.ext['buildProperties'].getProperty('server.base'))
+        File deployDir = new File (serverBase, "webapps/${project.name}")
+        println "classes: ${deployDir}/WEB-INF/classes"
+
+        ant.setLifecycleLogLevel('INFO')
+        ant.java(fork: true, failonerror: true, dir: rootProject.projectDir, classname: 'org.danann.cernunnos.runtime.Main') {
+            classpath {
+                pathelement(location: "${deployDir}/WEB-INF/classes")
+                pathelement(location: "${deployDir}/WEB-INF/lib/*")
+                project.configurations.impexp.files.each {
+                    pathelement(location: it.absolutePath)
+                }
+            }
+            sysproperty(key: 'portal.home', value: project.rootProject.ext['buildProperties'].getProperty('portal.home'))
+            sysproperty(key: 'logback.configurationFile', value: 'command-line.logback.xml')
+            arg(value: 'classpath://org/jasig/portlet/newsreader/io/import.crn.xml')
+            arg(value: "${dirEscaped}")
+        }
+    }
+}
+
+dataExport {
+    doLast {
+        String dir = System.getProperty('dir') ?: "${buildDir}/export"
+        String dirEscaped = PortalShellInvoker.createGroovySafePath(dir)
+        println "Export directory: ${dirEscaped}"
+
+        File serverBase = rootProject.file(rootProject.ext['buildProperties'].getProperty('server.base'))
+        File deployDir = new File (serverBase, "webapps/${project.name}")
+        println "classes: ${deployDir}/WEB-INF/classes"
+
+        ant.setLifecycleLogLevel('INFO')
+        ant.java(fork: true, failonerror: true, dir: rootProject.projectDir, classname: 'org.danann.cernunnos.runtime.Main') {
+            classpath {
+                pathelement(location: "${deployDir}/WEB-INF/classes")
+                pathelement(location: "${deployDir}/WEB-INF/lib/*")
+                project.configurations.impexp.files.each {
+                    pathelement(location: it.absolutePath)
+                }
+            }
+            sysproperty(key: 'portal.home', value: project.rootProject.ext['buildProperties'].getProperty('portal.home'))
+            sysproperty(key: 'logback.configurationFile', value: 'command-line.logback.xml')
+            arg(value: 'classpath://org/jasig/portlet/newsreader/io/export.crn.xml')
+            arg(value: "${dirEscaped}")
+        }
+    }
+}


### PR DESCRIPTION
./gradlew :overlays:NewsReaderPortlet:dataImport -Ddir=...

<!--
Thank you for your pull request. Please review below requirements.

Bug fixes and new features should be reported on the issue tracker: https://issues.jasig.org/browse/UP/

Contributors guide: https://github.com/Jasig/uPortal/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

-   [x] the [individual contributor license agreement][] is signed
-   [x] commit message follows [commit guidelines][]
-   [ ] tests are included
-   [ ] documentation is changed or added
-   [ ] [message properties][] have been updated with new phrases
-   [ ] view conforms with [WCAG 2.0 AA][]

##### Description of change
<!-- Provide a description of the change below this comment. -->


<!-- Reference Links -->

[individual contributor license agreement]: https://github.com/Jasig/uPortal/blob/master/.github/CONTRIBUTING.md#individual-contributor-license-agreement
[commit guidelines]: https://github.com/Jasig/uPortal/blob/master/.github/CONTRIBUTING.md#commit
[message properties]: https://github.com/Jasig/uPortal/tree/master/uportal-war/src/main/resources/properties/i18n
[WCAG 2.0 AA]: https://www.w3.org/WAI/WCAG20/quickref/?levels=aaa&technologies=smil%2Cpdf%2Cflash%2Csl
