### PR TITLE
fix: correct Xerces classpath loading conflict

### DIFF
--- a/overlays/uPortal/build.gradle
+++ b/overlays/uPortal/build.gradle
@@ -138,9 +138,10 @@ else {
     String skinTmpDir = "${buildDir}/tmp/skin/uPortal/media/skins/respondr/"
     // Identify custom skins located in skinsDir
     logger.lifecycle "Preparing Gradle tasks to compile the following custom skin files defined in ${skinsDir}"
-    List<String> skinFiles = new FileNameFinder().getFileNames(skinsDir.path, '*.less')
+    FileTree skinFiles = fileTree(dir: skinsDir, include: "**/*.less")
     // Step 3:  Use NodeJS & lessc to compile custom skin(sz)
-    skinFiles.eachWithIndex { it, index ->
+    skinFiles.eachWithIndex { f, index ->
+        String it = f.toString()
         // Strip the path
         String skinFileName = it.substring(it.lastIndexOf(File.separator) + 1)
         logger.lifecycle "  -> ${skinFileName} $index"


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.

Bug fixes and new features should be reported on the issue tracker: https://issues.jasig.org/browse/UP/

Contributors guide: https://github.com/Jasig/uPortal/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

-   [x] the [individual contributor license agreement][] is signed
-   [x] commit message follows [commit guidelines][]

##### Description of change
<!-- Provide a description of the change below this comment. -->
Started receiving errors about line 145 in overlays/uPortal/build.gradle around Xerces version conflicts. `FileNameFinder` is deprecated. Replacing this with FileTree resolved the error.

<!-- Reference Links -->

[individual contributor license agreement]: https://github.com/Jasig/uPortal/blob/master/.github/CONTRIBUTING.md#individual-contributor-license-agreement
[commit guidelines]: https://github.com/Jasig/uPortal/blob/master/.github/CONTRIBUTING.md#commit
[message properties]: https://github.com/Jasig/uPortal/tree/master/uportal-war/src/main/resources/properties/i18n
[WCAG 2.0 AA]: https://www.w3.org/WAI/WCAG20/quickref/?levels=aaa&technologies=smil%2Cpdf%2Cflash%2Csl
