### PR TITLE
Add Announcements Playwright tests and resource-server API tests

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,7 +1,7 @@
 version=5.0.0-SNAPSHOT
 
 # Versions of Bundled Applications under `overlays/`
-announcementsPortletVersion=2.5.0
+announcementsPortletVersion=2.5.1-SNAPSHOT
 basicltiPortletVersion=1.5.0
 bookmarksPortletVersion=1.3.0
 calendarPortletVersion=2.7.0
@@ -17,9 +17,9 @@ notificationPortletVersion=4.8.0
 # Required for very old front-end dependencies
 resourceServerVersion=1.0.48
 # Includes newer front-end dependencies and web components
-resourceServerWebjarVersion=1.5.0
+resourceServerWebjarVersion=1.5.1-SNAPSHOT
 simpleContentPortletVersion=3.4.0
-uPortalVersion=5.17.1
+uPortalVersion=5.17.3-SNAPSHOT
 webProxyPortletVersion=2.4.0
 
 # Versions of WebJars included with resource-server

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,7 +1,7 @@
 version=5.0.0-SNAPSHOT
 
 # Versions of Bundled Applications under `overlays/`
-announcementsPortletVersion=2.5.1-SNAPSHOT
+announcementsPortletVersion=2.5.0
 basicltiPortletVersion=1.5.0
 bookmarksPortletVersion=1.3.0
 calendarPortletVersion=2.7.0
@@ -17,9 +17,9 @@ notificationPortletVersion=4.8.0
 # Required for very old front-end dependencies
 resourceServerVersion=1.0.48
 # Includes newer front-end dependencies and web components
-resourceServerWebjarVersion=1.5.1-SNAPSHOT
+resourceServerWebjarVersion=1.5.0
 simpleContentPortletVersion=3.4.0
-uPortalVersion=5.17.3-SNAPSHOT
+uPortalVersion=5.17.1
 webProxyPortletVersion=2.4.0
 
 # Versions of WebJars included with resource-server

--- a/tests/ux/portlets/announcements.spec.ts
+++ b/tests/ux/portlets/announcements.spec.ts
@@ -1,0 +1,115 @@
+import { test, expect } from "@playwright/test";
+import { loginViaUrl } from "../utils/ux-general-utils";
+import { config } from "../../general-config";
+
+const ANNOUNCEMENTS_URL = `${config.url}p/announcements/max/render.uP`;
+const ANNOUNCEMENTS_ADMIN_URL = `${config.url}p/announcementsAdmin/max/render.uP`;
+
+test.describe("Announcements Display Portlet", () => {
+  test("renders display portlet container", async ({ page }) => {
+    await loginViaUrl(page, config.users.admin);
+    await page.goto(ANNOUNCEMENTS_URL);
+
+    const container = page.locator(".announcements-container");
+    await expect(container).toBeVisible();
+
+    await expect(page.getByText("My Subscriptions")).toBeVisible();
+    await expect(page.getByText("Archives")).toBeVisible();
+  });
+});
+
+test.describe("Announcements Admin Portlet", () => {
+  test("renders admin view with topics", async ({ page }) => {
+    await loginViaUrl(page, config.users.admin);
+    await page.goto(ANNOUNCEMENTS_ADMIN_URL);
+
+    const container = page.locator(".announcements-container");
+    await expect(container).toBeVisible();
+
+    await expect(page.getByRole("link", { name: "Campus Services" })).toBeVisible();
+  });
+
+  test("navigate to topic and view announcements", async ({ page }) => {
+    await loginViaUrl(page, config.users.admin);
+    await page.goto(ANNOUNCEMENTS_ADMIN_URL);
+
+    await page.getByRole("link", { name: "Campus Services" }).click();
+
+    await expect(
+      page.locator("a[href*='addAnnouncement']").first()
+    ).toBeVisible();
+  });
+
+  test("add announcement form loads with TinyMCE", async ({ page }) => {
+    await loginViaUrl(page, config.users.admin);
+    await page.goto(ANNOUNCEMENTS_ADMIN_URL);
+
+    await page.getByRole("link", { name: "Campus Services" }).click();
+    await page.locator("a[href*='addAnnouncement']").first().click();
+
+    await expect(page.locator("input#title")).toBeVisible();
+    await expect(page.locator("textarea[name='abstractText']")).toBeVisible();
+    await expect(page.locator("input[name='startDisplay']")).toBeVisible();
+    await expect(page.locator("input[name='endDisplay']")).toBeVisible();
+    await expect(
+      page.getByRole("button", { name: "Save Announcement" })
+    ).toBeVisible();
+
+    // TinyMCE editor should have initialized
+    await page.waitForTimeout(2000);
+    const mceState = await page.evaluate(() => {
+      const t = (window as any).tinymce || (window as any).tinyMCE;
+      return { editors: t?.editors?.length || 0 };
+    });
+    expect(mceState.editors).toBeGreaterThan(0);
+  });
+
+  test("create, verify, and delete announcement", async ({ page }) => {
+    await loginViaUrl(page, config.users.admin);
+    await page.goto(ANNOUNCEMENTS_ADMIN_URL);
+
+    await page.getByRole("link", { name: "Campus Services" }).click();
+    await page.locator("a[href*='addAnnouncement']").first().click();
+
+    // Fill in the form
+    const title = `PW Test ${Date.now()}`;
+    await page.fill("input#title", title);
+    await page.fill("textarea[name='abstractText']", "Playwright test abstract");
+
+    // Wait for TinyMCE to init, then set content via API
+    await page.waitForFunction(
+      () => !!(window as any).tinymce?.activeEditor,
+      { timeout: 10000 }
+    );
+    await page.evaluate(() => {
+      (window as any).tinymce.activeEditor.setContent(
+        "<p>Playwright test message body</p>"
+      );
+    });
+
+    // Set dates
+    const today = new Date();
+    const endDate = new Date(today.getTime() + 30 * 24 * 60 * 60 * 1000);
+    // jQuery UI datepicker format is 'yy-mm-dd' which means YYYY-MM-DD
+    const formatDate = (d: Date) =>
+      `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, "0")}-${String(d.getDate()).padStart(2, "0")}`;
+
+    await page.fill("input[name='startDisplay']", formatDate(today));
+    await page.fill("input[name='endDisplay']", formatDate(endDate));
+
+    // Submit
+    await page.getByRole("button", { name: "Save Announcement" }).click();
+
+    // Verify announcement appears in topic view
+    await expect(page.getByText(title)).toBeVisible({ timeout: 10000 });
+
+    // Delete it — delete is a form submit with a confirm dialog
+    page.once("dialog", (dialog) => dialog.accept());
+    const row = page.locator("tr", { hasText: title });
+    await row.locator("button[type='submit']").click();
+
+    // Verify it's gone
+    await page.waitForLoadState("networkidle");
+    await expect(page.getByText(title)).not.toBeVisible({ timeout: 10000 });
+  });
+});


### PR DESCRIPTION
## Summary

Adds test coverage in two areas as part of the April 2026 release prep:

### Playwright smoke tests for Announcements portlet (`tests/ux/portlets/`)

Five tests covering:
- Display portlet renders with container and nav links
- Admin view renders with topics
- Navigate into topic, add announcement link visible
- Add announcement form loads with TinyMCE editor
- Full CRUD: create announcement → verify → delete → confirm gone

### Resource-server API integration tests (`tests/api/resource-server.spec.ts`)

Sixteen tests covering both deployed webapps:
- **Legacy `/ResourceServingWebapp/rs/**`** — jQuery 1.12.4, jQuery UI 1.11.4, 404 handling
- **Modern `/resource-server/rs/**`** overlay — jQuery 3.7.1, jQuery UI 1.14.1, Bootstrap 5.0.2, cache headers, 404
- **Modern `/resource-server/webjars/**`** via webjars-locator — jQuery 4.0.0 (versioned + version-less), Bootstrap 5.3.8 JS/CSS, jQuery UI 1.14.1, DataTables 2.3.7, 404
- **Minification sanity check** — `.min` files are at least 30% smaller than unminified source, guarding against silent-fallback regressions in the esbuild pipeline (see [resource-server#309](https://github.com/uPortal-Project/resource-server/issues/309))

Each test verifies HTTP status, content-type, and spot-checks the response body contains expected library identifiers to catch cases where a path returns 200 but with wrong content.

Total runtime: ~15s for all 21 tests combined.

## Test plan

- [ ] Start HSQLDB + Tomcat with `portalInit`
- [ ] Run `npx playwright test tests/ux/portlets/announcements.spec.ts --config=tests/uportal-pw.config.ts` — all 5 pass
- [ ] Run `npx playwright test tests/api/resource-server.spec.ts --config=tests/uportal-pw.config.ts` — all 16 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)