### PR TITLE
chore(deps): bump CalendarPortlet 2.7.3 -> 2.7.4

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -4,7 +4,7 @@ version=5.0.0-SNAPSHOT
 announcementsPortletVersion=2.5.3
 basicltiPortletVersion=1.5.1
 bookmarksPortletVersion=1.3.1
-calendarPortletVersion=2.7.3
+calendarPortletVersion=2.7.4
 # Do not upgrade bundled CAS -- Quickstart Customizations
 casServerVersion=3.6.0
 casProxyTestPortletVersion=1.0.2


### PR DESCRIPTION
## Summary

Bump `calendarPortletVersion` from `2.7.3` to `2.7.4` to pick up the JodaModule serialization fix and the Backbone retirement work. Clears master CI red.

## Why now

Master CI has been failing since #695 (SNI fix in `setenv`) merged on May 9. The SNI fix wasn't the regression — it exposed a latent bug in CalendarPortlet 2.7.3:

- With SNI re-enabled, outbound HTTPS calendar fetches succeed (where before they silently failed at the TLS layer).
- Successful fetches produce an events response that serializes `org.joda.time.DateTime` fields through Jackson.
- Without `jackson-datatype-joda` on the classpath, Jackson 500s the response with `InvalidDefinitionException: Joda date/time type org.joda.time.DateTime not supported by default`.
- The legacy `calendar.js` has only a `$.ajax success` handler, no error path — so on 500 the loading spinner stays up.
- Playwright `tests/ux/portlets/calendar.spec.ts:47` (`event list renders without leaking Underscore template sigils`) expects `.upcal-event-list` to become visible, which it never does.

## Changes

- `gradle.properties`: `calendarPortletVersion=2.7.3` → `2.7.4`.

## What 2.7.4 ships

- [uPortal-Project/CalendarPortlet#407](https://github.com/uPortal-Project/CalendarPortlet/pull/407) — `jackson-datatype-joda` dependency + `JodaModule` registration on the JSON view's ObjectMapper. The actual fix for this issue.
- [uPortal-Project/CalendarPortlet#409](https://github.com/uPortal-Project/CalendarPortlet/pull/409) — replace Backbone narrow + wide + edit views with a vanilla `<calendar-portlet>` custom element; delete `scripts/calendar.js` and `WEB-INF/jsp/scripts.jsp`; drop the `<js>` entry from `skin-shared.xml`. UX unchanged; the deploy is ~270 LOC of legacy JS smaller and Backbone/Underscore are no longer in the portlet's runtime path.
- [uPortal-Project/CalendarPortlet#405](https://github.com/uPortal-Project/CalendarPortlet/pull/405), [#406](https://github.com/uPortal-Project/CalendarPortlet/pull/406), [#408](https://github.com/uPortal-Project/CalendarPortlet/pull/408) — chore cleanups, renovate-noise blockers, `uPortal-spring 5.17.5`.

Verified live on Maven Central via a `repo1.maven.org` HEAD probe before opening this PR.

## Test plan

- [ ] CI green (the calendar.spec.ts:47 regression that's been failing on master goes away).
- [ ] `./gradlew :overlays:CalendarPortlet:tomcatDeploy` produces a working WAR.
- [ ] Visit `/uPortal/p/calendar/normal/render.uP` (narrow) — events render, day/week/month buttons toggle, native date input works.
- [ ] Visit `/uPortal/p/calendar/max/render.uP` (wide) — events render in the left column, my-calendars sidebar with show/hide/export still works on the right.
- [ ] `npx playwright test --config tests/uportal-pw.config.ts tests/ux/portlets/calendar.spec.ts` — all 4 tests pass.