### PR TITLE
docs: enable combined access-log pattern + audit recipes

### DIFF
--- a/docs/access-log-audit.md
+++ b/docs/access-log-audit.md
@@ -73,3 +73,7 @@ that means either:
   Tomcat-internal forward, or a monitoring probe).
 
 In that case fall back to inspecting the source: `grep -r 'ResourceServingWebapp' overlays/` (or the equivalent path in your customizations repo) usually finds the literal string in a JSP, skin XML, or Spring config.
+
+## Future direction
+
+The file-based access log this doc grep's against is the lowest-common-denominator audit surface — useful precisely because Tomcat emits it already, with no extra infrastructure to run. A more durable path for observability work is OpenTelemetry's [Logs Data Model](https://opentelemetry.io/docs/specs/otel/logs/data-model/): structured log records ingested by a collector and fanned out to the deployer's logging backend, where attribute-based queries replace text grep entirely. uPortal-start does not currently ship OTEL instrumentation; adding it is tracked separately and would be the right long-term place for the audits described above.

--- a/docs/access-log-audit.md
+++ b/docs/access-log-audit.md
@@ -1,0 +1,75 @@
+# Auditing Tomcat access logs
+
+Every HTTP request Tomcat answers is captured in
+`${CATALINA_BASE}/logs/localhost_access_log.<date>.txt`. For dev clones built
+via `./gradlew portalInit`, that resolves to
+`uPortal-start/.gradle/tomcat/logs/localhost_access_log.<date>.txt`.
+
+uPortal-start ships an `AccessLogValve` configured with the "combined" pattern
+(Apache httpd's standard extended log format). Each line looks like:
+
+```
+127.0.0.1 - - [13/May/2026:23:14:02 -0700] "GET /uPortal/render.uP HTTP/1.1" 200 8123 "https://portal.example.edu/uPortal/Login" "Mozilla/5.0 …"
+```
+
+The fields are: client IP, remote logname, remote user, timestamp, request
+line, status, bytes sent, **Referer**, **User-Agent**.
+
+The two extra fields are what makes the log useful for audits: when you see a
+suspicious URL being requested, the Referer tells you which page emitted the
+link, and the User-Agent disambiguates browsers from monitoring agents.
+
+## Auditing during the `ResourceServingWebapp` retirement
+
+uPortal-Project is consolidating its frontend asset paths from
+`/ResourceServingWebapp/...` onto `/resource-server/...`. As of uPortal v5.17.8,
+SimpleContentPortlet 3.4.3, FeedbackPortlet 1.3.2, and NewsReaderPortlet 5.1.5,
+nothing in the community fleet should request the legacy path. To confirm the
+same on your portal:
+
+```sh
+$ cd ${CATALINA_BASE}/logs
+$ grep "ResourceServingWebapp" localhost_access_log.*.txt | wc -l
+0
+```
+
+A non-zero count means something still references the legacy path. The Referer
+tells you which page to fix:
+
+```sh
+$ grep "ResourceServingWebapp" localhost_access_log.*.txt | head -5
+127.0.0.1 - admin [14/May/2026:08:11:42 -0700] "GET /ResourceServingWebapp/rs/lodash/4.17.4/lodash.min.js HTTP/1.1" 200 73450 "http://localhost:8080/uPortal/p/some-custom-portlet/max/render.uP" "Mozilla/5.0 …"
+```
+
+In the example above, `/p/some-custom-portlet/max/render.uP` is the page still
+emitting the legacy URL — likely a deployer-customized portlet whose JSP or
+skin overlay needs updating.
+
+## General audit recipes
+
+Same `grep` shape works for any audit you need to run against requests reaching
+Tomcat:
+
+```sh
+# All 404s grouped by URL — find broken links and dead overlays
+awk -F'"' '{print $2, $3}' localhost_access_log.*.txt | grep ' 404 ' | sort | uniq -c | sort -rn | head -20
+
+# Requests from a specific bot, by URL — sanity-check what crawlers see
+grep 'Googlebot' localhost_access_log.*.txt | awk -F'"' '{print $2}' | sort -u
+
+# 5xx errors with their referring pages — surface server-side breakages and
+# the page that triggered them
+grep -E ' (5[0-9][0-9]) [0-9]+ ' localhost_access_log.*.txt | head -20
+```
+
+## When the log seems unhelpful
+
+If `grep "ResourceServingWebapp"` returns hits but the Referer field is `-`,
+that means either:
+
+- The request came from JavaScript (`fetch`, `XMLHttpRequest`) where the
+  browser deliberately omits the Referer header for some configurations, or
+- The request came from a non-browser client (a server-to-server call, a
+  Tomcat-internal forward, or a monitoring probe).
+
+In that case fall back to inspecting the source: `grep -r 'ResourceServingWebapp' overlays/` (or the equivalent path in your customizations repo) usually finds the literal string in a JSP, skin XML, or Spring config.

--- a/etc/tomcat/conf/server.xml
+++ b/etc/tomcat/conf/server.xml
@@ -165,10 +165,14 @@
 
         <!-- Access log processes all example.
              Documentation at: /docs/config/valve.html
-             Note: The pattern used is equivalent to using pattern="common" -->
+             Note: The pattern below is "combined" (Apache httpd's standard
+             extended log format) — it captures Referer and User-Agent in
+             addition to the "common" fields. See docs/access-log-audit.md
+             for how to use those fields when triangulating which page is
+             still requesting a given URL. -->
         <Valve className="org.apache.catalina.valves.AccessLogValve" directory="logs"
                prefix="localhost_access_log" suffix=".txt"
-               pattern="%h %l %u %t &quot;%r&quot; %s %b" />
+               pattern="%h %l %u %t &quot;%r&quot; %s %b &quot;%{Referer}i&quot; &quot;%{User-Agent}i&quot;" />
 
       </Host>
     </Engine>


### PR DESCRIPTION
## Summary

- Swap the `AccessLogValve` pattern in `etc/tomcat/conf/server.xml` from the "common" format to the "combined" format (Apache httpd's standard extended log) — adds Referer and User-Agent to every log line
- Add `docs/access-log-audit.md` with worked examples: confirming the `ResourceServingWebapp` retirement is complete on a live portal, and general audit recipes (404s by URL, bot traffic, 5xx with referrer, what to do when Referer is empty)

## Why

The "common" format captures method + URL but not Referer. When auditing live traffic for stragglers — e.g. confirming that no caller still hits `/ResourceServingWebapp/` after the consolidation lands (uPortal v5.17.8 + SimpleContent 3.4.3 + Feedback 1.3.2 + NewsReader 5.1.5) — a hit tells you the asset URL but not the page that emitted it.

In a community-build fleet the consolidation work I just merged in #694 is sufficient to drive that count to zero, and the dev quickstart's access log confirms it. But deployers who run customized portals (locally-developed portlets, skin overlays, third-party integrations) will need a way to find stragglers in their own setups. The combined format makes that a single grep.

## What changed

- `etc/tomcat/conf/server.xml`: `pattern="%h %l %u %t \"%r\" %s %b"` → `pattern="%h %l %u %t \"%r\" %s %b \"%{Referer}i\" \"%{User-Agent}i\""`, plus an explanatory comment pointing at the new doc
- `docs/access-log-audit.md` (new): log location, field reference, worked example for the resource-server retirement, general grep recipes, fallback when Referer is empty

## Test plan

- [ ] `./gradlew tomcatStart`; visit `http://localhost:8080/uPortal/`; tail `.gradle/tomcat/logs/localhost_access_log.<today>.txt`; confirm new lines include the two quoted Referer/User-Agent fields
- [ ] On a fresh stack (current master + the bumps from #694), `grep ResourceServingWebapp` against the access log returns 0 — confirms the doc's worked example reflects reality