### PR TITLE
chore(deps): bump SimpleContentPortlet to 3.4.4

### DIFF
--- a/gradle.properties.example
+++ b/gradle.properties.example
@@ -16,7 +16,7 @@ notificationPortletVersion=4.8.4
 resourceServerVersion=1.0.48
 # Includes newer front-end dependencies and web components
 resourceServerWebjarVersion=1.5.3
-simpleContentPortletVersion=3.4.3
+simpleContentPortletVersion=3.4.4
 uPortalVersion=5.17.8
 webProxyPortletVersion=2.4.1
 


### PR DESCRIPTION
Problem: uPortal-start pins SimpleContentPortlet **3.4.3**, which still ships AWS SDK **v1** (out of security support). Deployers have received AWS end-of-life warning emails for the bundled SDK.

Goal: pull in SimpleContentPortlet **3.4.4** so deployers get the AWS SDK v2 attachment-storage migration.

Changes:
- `gradle.properties.example`: `simpleContentPortletVersion` 3.4.3 → 3.4.4

Notes: 3.4.4 is published to Maven Central; it migrates the S3 attachment persistence strategy from AWS SDK v1 to v2.

⚠️ **S3-backed deployers** may need to set an AWS region explicitly — v2 resolves region strictly (via `AWS_REGION` / profile / instance metadata) and fails fast if none is set, whereas v1 sometimes defaulted to `us-east-1`. Deployers using DB attachment storage (the default) are unaffected.