### PR TITLE
chore(deps): bump uPortal to 5.17.9

### DIFF
--- a/gradle.properties.example
+++ b/gradle.properties.example
@@ -17,7 +17,7 @@ resourceServerVersion=1.0.48
 # Includes newer front-end dependencies and web components
 resourceServerWebjarVersion=1.5.3
 simpleContentPortletVersion=3.4.3
-uPortalVersion=5.17.8
+uPortalVersion=5.17.9
 webProxyPortletVersion=2.4.1
 
 # Versions of WebJars included with resource-server


### PR DESCRIPTION
Problem: uPortal-start pins uPortal **5.17.8**. The **5.17.9** patch release is now on Maven Central.

Goal: pull uPortal 5.17.9 into uPortal-start so deployers get its fixes.

Changes:
- `gradle.properties.example`: `uPortalVersion` 5.17.8 → 5.17.9

What 5.17.9 brings (see the [v5.17.9 release notes](https://github.com/uPortal-Project/uPortal/releases/tag/v5.17.9)):
- **Security:** drop transitive `log4j-core` (Log4Shell-family CVE surface) + bridge log4j2→slf4j; migrate dynamic-skin S3 storage off the out-of-support AWS SDK v1 to v2.
- **Fixes:** JGroups `JDBC_PING` zombie-row accumulation; LESS `@import (inline)` skin path 404.

⚠️ The AWS SDK v2 region caveat only affects deployers who **enabled the opt-in dynamic-skin S3 storage backend** (off by default); they may need to set an explicit `AWS_REGION`.