### PR TITLE
feat(skin): add SCSS compilation support for custom skins

### DIFF
--- a/etc/skin/skinName.scss
+++ b/etc/skin/skinName.scss
@@ -1,0 +1,30 @@
+/**
+ * Licensed to Apereo under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work
+ * for additional information regarding copyright ownership.
+ * Apereo licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License.  You may obtain a
+ * copy of the License at the following location:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+/**
+ * For information on how to skin uPortal
+ * @see docs/SKINNING_UPORTAL.md
+ */
+
+/** WARNING:  DO NOT REMOVE OR ALTER THIS LINE **/
+@import "common/scss/common";
+/*******************************************/
+
+@import "${skinName}/scss/variables";
+@import "${skinName}/scss/skin";

--- a/etc/skin/skinName/scss/skin.scss
+++ b/etc/skin/skinName/scss/skin.scss
@@ -1,0 +1,24 @@
+/**
+ * Licensed to Apereo under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work
+ * for additional information regarding copyright ownership.
+ * Apereo licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License.  You may obtain a
+ * copy of the License at the following location:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+/**
+ * This file is for skin-specific overrides.  Add your custom styles here.
+ * Variables from variables.scss are available, along with all of Bootstrap 5's
+ * variables and mixins (imported via common/scss/common).
+ */

--- a/etc/skin/skinName/scss/variables.scss
+++ b/etc/skin/skinName/scss/variables.scss
@@ -1,0 +1,121 @@
+/**
+ * Licensed to Apereo under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work
+ * for additional information regarding copyright ownership.
+ * Apereo licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License.  You may obtain a
+ * copy of the License at the following location:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+/* ==========================================================================
+   Variables
+   ========================================================================== */
+$white: #FFFFFF;
+$black: #000000;
+
+/*
+ * Grayscale colors. 1 is lightest, 10 is darkest.
+ */
+$grayscale1:  #F5F5F5;
+$grayscale2:  #E5E5E5;
+$grayscale3:  #D8D8D8;
+$grayscale4:  #CCCCCC;
+$grayscale5:  #ADADAD;
+$grayscale6:  #999999;
+$grayscale7:  #8C8C8C;
+$grayscale8:  #696969;
+$grayscale9:  #404040;
+$grayscale10: #333333;
+
+/*
+ * Primary color with 3 lightened shades and 3 darkened shades.
+ *
+ * The variable color1 is used by the DynamicRespondrSkin portlet.
+ * 1) Do not change the variable name.
+ * 2) The value must be on the same line as the variable name and be terminated with a semicolon.
+ */
+$color1: #4065B0; // medium blue
+$color1-light: lighten($color1, 10%);
+$color1-lighter: lighten($color1, 25%);
+$color1-lightest: lighten($color1, 50%);
+$color1-dark: darken($color1, 10%);
+$color1-darker: darken($color1, 25%);
+$color1-darkest: darken($color1, 50%);
+
+/*
+ * Secondary color with 3 lightened shades and 3 darkened shades.
+ */
+$color2: #F68923; // muted orange
+$color2-light: lighten($color2, 10%);
+$color2-lighter: lighten($color2, 25%);
+$color2-lightest: lighten($color2, 50%);
+$color2-dark: darken($color2, 10%);
+$color2-darker: darken($color2, 25%);
+$color2-darkest: darken($color2, 50%);
+
+/*
+ * Link color with 1 lighter shade.
+ */
+$color3: #317ab9; // light muted blue
+$color3-light: lighten($color3, 15%);
+
+/*
+ * Footer text color with 1 lighter shade.
+ */
+$color4: #ADADAD; // light gray
+$color4-light: lighten($color4, 15%);
+$color4-lighter: lighten($color4, 30%);
+
+/*
+ * Footer background color.
+ */
+$color5: #333333; // dark gray
+
+/*
+ * Portlet border color.
+ */
+$color6: #E5E5E5; // lighter gray
+
+$border: 1px solid $grayscale2;
+
+/**
+ * Link colors
+ */
+$portal-link-color: $color3;
+$portal-link-hover-color: $color3-light;
+
+/**
+ * Region styles
+ */
+$header-background-color: $color1;
+$header-text-color: $white;
+$header-link-color: $white;
+
+$footer-background-color: $color5;
+$footer-secondary-background-color: lighten($color5, 10%);
+$footer-text-color: $color4-light;
+$footer-link-color: $color4-lighter;
+$footer-link-hover-color: $white;
+
+/**
+ * Page-level styles
+ */
+$body-background-color: $footer-secondary-background-color;
+
+/**
+ * Portlet Chrome Settings
+ */
+$portlet-border-color: $color6;
+$portlet-border-radius: 5px;
+$portlet-titlebar-link-color: $grayscale10;
+$portlet-titlebar-background-color: $grayscale2;

--- a/overlays/uPortal/build.gradle
+++ b/overlays/uPortal/build.gradle
@@ -42,12 +42,70 @@ import java.util.regex.Pattern
 File skinsDir = rootProject.file("${projectDir}/src/main/webapp/media/skins/respondr")
 task skinGenerate() {
     group 'Skin'
-    description 'Genarate a new uPortal skin for Respondr;  pass -DskinName={name} (required) to specify a name'
+    description 'Generate a new SCSS-based uPortal skin for Respondr;  pass -DskinName={name} (required) to specify a name'
 
     doLast {
         String skinName = System.getProperty('skinName');
         if (skinName == null || skinName.isEmpty()) {
-            throw new GradleException('You must specify a skinName JVM argment to invoke the skinGenerate task')
+            throw new GradleException('You must specify a skinName JVM argument to invoke the skinGenerate task')
+        }
+
+        // We have a name;  but is it valid?
+        if (!Pattern.matches(/[a-zA-Z0-9]{3,20}/, skinName)) {
+            throw new GradleException('A valid skinName contains between 3 and 20 alphanumeric characters')
+        }
+        File skinFile = rootProject.file("${projectDir}/src/main/webapp/media/skins/respondr/${skinName}.scss")
+        File skinDir = rootProject.file("${projectDir}/src/main/webapp/media/skins/respondr/${skinName}")
+        if (skinFile.exists() || skinDir.exists()) {
+            throw new GradleException("Unable to generate a skin with the same name as an existing skin:  ${skinName}")
+        }
+
+        skinsDir.mkdirs()
+
+        // First the ${skinName}.scss entry-point file (uses Groovy expand for import paths)
+        copy {
+            from "${rootProject.projectDir}/etc/skin/skinName.scss"
+            into skinsDir
+            rename { return "${skinName}.scss" }
+            expand(skinName: skinName)
+        }
+
+        // Then the contents of the ${skinName}/scss folder (plain copy, no expand -- SCSS uses $ for variables)
+        File skinScssDir = rootProject.file("${projectDir}/src/main/webapp/media/skins/respondr/${skinName}/scss")
+        copy {
+            from "${rootProject.projectDir}/etc/skin/skinName/scss"
+            into skinScssDir
+        }
+
+        // Copy skin.xml
+        copy {
+            from "${rootProject.projectDir}/etc/skin/skinName/skin.xml"
+            into skinDir
+        }
+
+        // Copy skinList.xml if it does not exist
+        File skinListFile = rootProject.file("${projectDir}/src/main/webapp/media/skins/respondr/skinList.xml")
+        File respondrDir = rootProject.file("${projectDir}/src/main/webapp/media/skins/respondr")
+        if (!skinListFile.exists()) {
+            copy {
+                from "${rootProject.projectDir}/etc/skin/skinList.xml"
+                into respondrDir
+            }
+        }
+
+        logger.lifecycle("Generated new SCSS skin ${skinName} at the following location:  ${skinsDir}")
+        logger.lifecycle("IMPORTANT!  To use the ${skinName} skin (instead of the default) change the 'PREFdynamicSkinName' preference in dynamic-respondr-skin")
+    }
+}
+
+task skinGenerateLess() {
+    group 'Skin'
+    description 'Generate a new LESS-based uPortal skin for Respondr (legacy);  pass -DskinName={name} (required) to specify a name'
+
+    doLast {
+        String skinName = System.getProperty('skinName');
+        if (skinName == null || skinName.isEmpty()) {
+            throw new GradleException('You must specify a skinName JVM argument to invoke the skinGenerateLess task')
         }
 
         // We have a name;  but is it valid?
@@ -57,7 +115,7 @@ task skinGenerate() {
         File skinFile = rootProject.file("${projectDir}/src/main/webapp/media/skins/respondr/${skinName}.less")
         File skinDir = rootProject.file("${projectDir}/src/main/webapp/media/skins/respondr/${skinName}")
         if (skinFile.exists() || skinDir.exists()) {
-            throw new GradleException("Unable to generate a skin with the same neame as an existing skin:  ${skinName}")
+            throw new GradleException("Unable to generate a skin with the same name as an existing skin:  ${skinName}")
         }
 
         skinsDir.mkdirs()
@@ -72,9 +130,15 @@ task skinGenerate() {
 
         // Then the contents of the ${skinName} folder
         copy {
-            from "${rootProject.projectDir}/etc/skin/skinName"
-            into skinDir
+            from "${rootProject.projectDir}/etc/skin/skinName/less"
+            into rootProject.file("${projectDir}/src/main/webapp/media/skins/respondr/${skinName}/less")
             expand(skinName: skinName)
+        }
+
+        // Copy skin.xml
+        copy {
+            from "${rootProject.projectDir}/etc/skin/skinName/skin.xml"
+            into skinDir
         }
 
         // Copy skinList.xml if it does not exist
@@ -87,7 +151,7 @@ task skinGenerate() {
             }
         }
 
-        logger.lifecycle("Generated new skin ${skinName} at the following location:  ${skinsDir}")
+        logger.lifecycle("Generated new LESS skin ${skinName} at the following location:  ${skinsDir}")
         logger.lifecycle("IMPORTANT!  To use the ${skinName} skin (instead of the default) change the 'PREFdynamicSkinName' preference in dynamic-respondr-skin")
     }
 }
@@ -189,7 +253,7 @@ else {
     // Identify custom skins located in skinsDir
     logger.lifecycle "Preparing Gradle tasks to compile the following custom skin files defined in ${skinsDir}"
     FileTree skinFiles = fileTree(dir: skinsDir, include: "*.less")
-    // Step 3:  Use NodeJS & lessc to compile custom skin(sz)
+    // Step 3:  Use NodeJS & lessc to compile custom skin(s) (LESS)
     skinFiles.eachWithIndex { f, index ->
         String it = f.toString()
         // Strip the path
@@ -198,6 +262,24 @@ else {
 
         task "compileLess${index}"(type: NpmTask, dependsOn: prepareSkinResources) {
             args = ['run', 'compile-less', "${skinTmpDir}${skinFileName}", "${skinTmpDir}${skinFileName.replace('.less', '.css')}"]
+        }
+    }
+
+    // Step 4:  Use NodeJS & sass to compile custom skin(s) (SCSS)
+    // Bootstrap SCSS source is included in the upstream uPortal WAR's webjars;
+    // --load-path tells sass where to find bare @import "bootstrap" references.
+    String bootstrapScssLoadPath = "${buildDir}/tmp/skin/uPortal/webjars/bootstrap/scss"
+    FileTree scssFiles = fileTree(dir: skinsDir, include: "*.scss")
+    scssFiles.eachWithIndex { f, index ->
+        String it = f.toString()
+        // Strip the path
+        String skinFileName = it.substring(it.lastIndexOf(File.separator) + 1)
+        logger.lifecycle "  -> ${skinFileName} (scss) $index"
+
+        task "compileScss${index}"(type: NpmTask, dependsOn: prepareSkinResources) {
+            args = ['run', 'compile-scss', '--',
+                    "--load-path=${bootstrapScssLoadPath}",
+                    "${skinTmpDir}${skinFileName}:${skinTmpDir}${skinFileName.replace('.scss', '.css')}"]
         }
     }
 
@@ -218,7 +300,7 @@ else {
     }
 
     war.dependsOn {
-        tasks.findAll { task -> task.name.startsWith('compileLess') }
+        tasks.findAll { task -> task.name.startsWith('compileLess') || task.name.startsWith('compileScss') }
     }
 }
 

--- a/overlays/uPortal/package-lock.json
+++ b/overlays/uPortal/package-lock.json
@@ -6,7 +6,312 @@
     "": {
       "name": "uportal-start",
       "devDependencies": {
-        "less": "^3.13.0"
+        "less": "^3.13.0",
+        "sass": "^1.77.0"
+      }
+    },
+    "node_modules/@parcel/watcher": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher/-/watcher-2.6.0.tgz",
+      "integrity": "sha512-7FNeNl8NCE7aINx7WXiKQrPYZWC/hvrTsmk6zmxbI7LTXE7hVek/n8AfVgpe2y82zl3w0HvCHN0bVKMBoJcC0w==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "detect-libc": "^2.0.3",
+        "is-glob": "^4.0.3",
+        "node-addon-api": "^7.0.0",
+        "picomatch": "^4.0.4"
+      },
+      "engines": {
+        "node": ">= 10.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      },
+      "optionalDependencies": {
+        "@parcel/watcher-android-arm64": "2.6.0",
+        "@parcel/watcher-darwin-arm64": "2.6.0",
+        "@parcel/watcher-darwin-x64": "2.6.0",
+        "@parcel/watcher-freebsd-x64": "2.6.0",
+        "@parcel/watcher-linux-arm-glibc": "2.6.0",
+        "@parcel/watcher-linux-arm-musl": "2.6.0",
+        "@parcel/watcher-linux-arm64-glibc": "2.6.0",
+        "@parcel/watcher-linux-arm64-musl": "2.6.0",
+        "@parcel/watcher-linux-x64-glibc": "2.6.0",
+        "@parcel/watcher-linux-x64-musl": "2.6.0",
+        "@parcel/watcher-win32-arm64": "2.6.0",
+        "@parcel/watcher-win32-x64": "2.6.0"
+      }
+    },
+    "node_modules/@parcel/watcher-android-arm64": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-android-arm64/-/watcher-android-arm64-2.6.0.tgz",
+      "integrity": "sha512-trgpLSCKRC/huFjXX/Smh+0sWe4+YtKfktIToiMl59ghz7z+qkH6kMvNnUbLyRs9N11t8l4svSCs1+5B3rOAhA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">= 10.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@parcel/watcher-darwin-arm64": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-darwin-arm64/-/watcher-darwin-arm64-2.6.0.tgz",
+      "integrity": "sha512-Y3QV0gl7Q1zbfueunkWIERICbEojQFCgpyG7YqOGNFLsckXyI1xu9mAIUpKY9QBYzBtSkN8dBPwd3yiAO9ovMw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@parcel/watcher-darwin-x64": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-darwin-x64/-/watcher-darwin-x64-2.6.0.tgz",
+      "integrity": "sha512-Ohv6OpzhUfKYD7Beb8kDvG0jbIxORCYY1JRdZnaBtnjjkJxgD7ZVL0nw2sCYd0yTMKTvz3nnTnOF3cDifK+kvw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@parcel/watcher-freebsd-x64": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-freebsd-x64/-/watcher-freebsd-x64-2.6.0.tgz",
+      "integrity": "sha512-5HmXvDgs8VK+74jF9y9/2FE3/OnlcKmc56tjmSrEuZjpSZOGL+fvAu+HKJBdPs9uwoP2hE6TlSUpXZ/C5jUFmQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">= 10.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@parcel/watcher-linux-arm-glibc": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-linux-arm-glibc/-/watcher-linux-arm-glibc-2.6.0.tgz",
+      "integrity": "sha512-Ps/hui3A+vMbjdqlqAowK2ZL8+BO8dBjxeWXj6npTBs3jx4wWmbPpaLuqwrQrSqIVMCnpWo238bJ1U37GhQOYg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@parcel/watcher-linux-arm-musl": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-linux-arm-musl/-/watcher-linux-arm-musl-2.6.0.tgz",
+      "integrity": "sha512-9c6AUHgHoG+IY88MRIHupztQiQnrbqHYQjkM2btA+Bf/wQnQMuiD0Wfk1EVv3TlNT3x41uU71rn6E4xh/+zvkw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@parcel/watcher-linux-arm64-glibc": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-linux-arm64-glibc/-/watcher-linux-arm64-glibc-2.6.0.tgz",
+      "integrity": "sha512-yHRqS2owEXe6Hic9z6Mh1ECsCd+ODVOGvZDyciqRd21+v+o+DnXMOrw50DSpIG2sb8GPEaPPmfeCAWKPJdq46g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@parcel/watcher-linux-arm64-musl": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-linux-arm64-musl/-/watcher-linux-arm64-musl-2.6.0.tgz",
+      "integrity": "sha512-WhB2e/V7rqdHHWZusBSPuy5Ei8S6lSz6FE5TKKQz5h3a0O+C+mhY7vxU9b/stqvMb8beLnPY82ZrFTLKs+SrKA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@parcel/watcher-linux-x64-glibc": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-linux-x64-glibc/-/watcher-linux-x64-glibc-2.6.0.tgz",
+      "integrity": "sha512-ulGE6x6Oz6iAwg75T8YQSoguBWasniIbX+QWpaYPcCnDOpdWX3k+4xbEYPZVLxOuoJI+svJJPD3sEj8G7lrQ3A==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@parcel/watcher-linux-x64-musl": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-linux-x64-musl/-/watcher-linux-x64-musl-2.6.0.tgz",
+      "integrity": "sha512-tkBYKt7YQrjIJWYDnto2YgO8MRkjlMTSNoRHzsXinBqbLdeOM3L32wPZJvIZxqaLMfSlS/4sUjH/6STVP/XDLw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@parcel/watcher-win32-arm64": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-win32-arm64/-/watcher-win32-arm64-2.6.0.tgz",
+      "integrity": "sha512-gIZAP23jaHjGWasY/TY6yL7NHFClf0Ga7FN+iINvk+KN94rhm94lYZhFsbYFNcA04/onvGD9kKmiJLJB2HbNwQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@parcel/watcher-win32-x64": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-win32-x64/-/watcher-win32-x64-2.6.0.tgz",
+      "integrity": "sha512-cA+/pXV2YkfxlIcXOQ5fSWqAzzPyD78/x5qbK/I0vUkrlYHA8TIz+MXjAbGouguKVSI4bOmkTSJ1/poVSsgt+A==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/chokidar": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-5.0.0.tgz",
+      "integrity": "sha512-TQMmc3w+5AxjpL8iIiwebF73dRDF4fBIieAqGn9RGCWaEVwQ6Fb2cGe31Yns0RRIzii5goJ1Y7xbMwo1TxMplw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "readdirp": "^5.0.0"
+      },
+      "engines": {
+        "node": ">= 20.19.0"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
       }
     },
     "node_modules/copy-anything": {
@@ -19,6 +324,17 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/mesqueeb"
+      }
+    },
+    "node_modules/detect-libc": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
+      "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/errno": {
@@ -49,6 +365,38 @@
       "optional": true,
       "bin": {
         "image-size": "bin/image-size.js"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/immutable": {
+      "version": "5.1.9",
+      "resolved": "https://registry.npmjs.org/immutable/-/immutable-5.1.9.tgz",
+      "integrity": "sha512-m8nVez3rwrgmWxtLMt1ZYXB2Lv7OKYn/disyxAlSDYAlKSlFoPPfIAmAM/M5xqL4m4C/wAPw7S2/CNaUii1Hxg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/is-extglob": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
+      "integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-glob": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
+      "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "is-extglob": "^2.1.1"
       },
       "engines": {
         "node": ">=0.10.0"
@@ -119,6 +467,28 @@
       "dev": true,
       "optional": true
     },
+    "node_modules/node-addon-api": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-7.1.1.tgz",
+      "integrity": "sha512-5m3bsyrjFWE1xf7nz7YXdN4udnVtXK6/Yfgn5qnahL6bCkf2yKt4k3nuTKAtT4r3IG8JNR2ncsIMdZuAzJjHQQ==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/picomatch": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.5.tgz",
+      "integrity": "sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
     "node_modules/pify": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/pify/-/pify-4.0.1.tgz",
@@ -136,6 +506,41 @@
       "dev": true,
       "optional": true
     },
+    "node_modules/readdirp": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-5.0.0.tgz",
+      "integrity": "sha512-9u/XQ1pvrQtYyMpZe7DXKv2p5CNvyVwzUB6uhLAnQwHMSgKMBR62lc7AHljaeteeHXn11XTAaLLUVZYVZyuRBQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 20.19.0"
+      },
+      "funding": {
+        "type": "individual",
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/sass": {
+      "version": "1.101.3",
+      "resolved": "https://registry.npmjs.org/sass/-/sass-1.101.3.tgz",
+      "integrity": "sha512-Z1lLHhtAII+dyLNIQB6JQTZMy7sDxk3f5NzbINRc9ks1P0HCGvSuKev0wUhULFpLSaHBIMZrcTs9WDQUZerrgA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "chokidar": "^5.0.0",
+        "immutable": "^5.1.5",
+        "source-map-js": ">=0.6.2 <2.0.0"
+      },
+      "bin": {
+        "sass": "sass.js"
+      },
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "optionalDependencies": {
+        "@parcel/watcher": "^2.4.1"
+      }
+    },
     "node_modules/semver": {
       "version": "5.7.2",
       "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.2.tgz",
@@ -152,6 +557,16 @@
       "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
       "dev": true,
       "optional": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/source-map-js": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
       "engines": {
         "node": ">=0.10.0"
       }

--- a/overlays/uPortal/package.json
+++ b/overlays/uPortal/package.json
@@ -2,9 +2,11 @@
   "name": "uportal-start",
   "private": true,
   "scripts": {
-    "compile-less": "lessc"
+    "compile-less": "lessc",
+    "compile-scss": "sass"
   },
   "devDependencies": {
-    "less": "^3.13.0"
+    "less": "^3.13.0",
+    "sass": "^1.77.0"
   }
 }


### PR DESCRIPTION
uPortal 5.17.5+ ships Bootstrap 5 SCSS source as a webjar inside the WAR, and the upstream defaultSkin is now compiled from SCSS. However, uPortal-start's overlay skinning pipeline only knew how to compile LESS files with lessc.

This commit adds a parallel SCSS compilation path so that custom skins authored in SCSS are compiled alongside existing LESS skins:

- Add sass to overlays/uPortal/package.json (devDep + script)
- Add compileScss Gradle tasks that scan for *.scss in the skins directory and invoke sass with --load-path pointing at the Bootstrap SCSS source inside the unpacked upstream WAR
- Refactor skinGenerate task to produce SCSS skins by default; rename the old LESS generator to skinGenerateLess
- Add etc/skin/skinName.scss template and etc/skin/skinName/scss/ directory with variables.scss and skin.scss scaffolding
- Update war.dependsOn to include compileScss tasks

Existing LESS-based skins continue to work unchanged. The skinGenerateLess task remains available for legacy use.
